### PR TITLE
chore: suppress r5py warning prints in CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ profile = "black"
 # `pytest` configurations
 [tool.pytest.ini_options]
 addopts = [
+    "-p no:faulthandler",
     "-vv",
     "--doctest-modules"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ profile = "black"
 # `pytest` configurations
 [tool.pytest.ini_options]
 addopts = [
-    "-p no:faulthandler",
     "-vv",
     "--doctest-modules"
 ]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -8,7 +8,6 @@ TODO: make this run 'on request' only.
 
 import pytest
 import os
-from r5py import TransportNetwork
 
 
 class TestSetup:
@@ -35,6 +34,10 @@ class TestSetup:
     @pytest.mark.setup
     def test_r5py_setup(self) -> None:
         """Check development environment will cope with r5py requirements."""
+        # this import is only here to prevent java messages being printed to
+        # the CLI when set-up pytests are not run
+        from r5py import TransportNetwork
+
         # search the ext dir for pbf & gtfs
         search_pth = os.path.join("tests", "data")
         foundf = os.listdir(search_pth)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Modified pytest config in pyproject.toml to not run `faulthandler` by default.

`faulthandler` is used to traceback segmentation/timeout issues. Running this 'by default' was introduced in pytest at v5.0.0. The "-p no:faulthandler" switch runs pytest as normal without `faulthandler` being active. This is controlled in the `pyproject.toml` config, so it becomes the default behaviour. See [pytest docs](https://docs.pytest.org/en/7.1.x/how-to/failures.html#fault-handler) for more info. Note: this strategy is also adopted by `r5py`.

Fixes #13 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
r5py warnings during pytest run clutter CLI which hides the results of the pytest run (message is too long). This correction suppresses those warning messages.

## Type of change
<!--- Please select from the options below --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

`pytest --runsetup` runs as expected, with r5py warnings cluttering CLI. Performing dummy tweaks to the assertion statements causes the test to fail, as expected (these dummy tweaks aren't committed).

Test configuration details:
* OS: macOS
* Python version: 3.9.12
* Java version: 11
* Python management system: conda

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
None