### PR TITLE
chore: CI run on all branches

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,6 @@ name: Python package
 
 on:
   push:
-    branches: [ "dev", "main" ]
   pull_request:
     branches: [ "dev", "main" ]
 


### PR DESCRIPTION
Really quick CI patch to:

* have CI run on all branch pushes by default
* CI runs on PR to dev and main