### PR TITLE
Refactored daily summaries

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,6 @@ name: Python package
 
 on:
   push:
-    branches: [ "dev", "main" ]
   pull_request:
     branches: [ "dev", "main" ]
 
@@ -42,7 +41,7 @@ jobs:
         pre-commit run --all-files
     - name: Test with pytest
       run: |
-        pytest
+        pytest --runsetup
     - name: Generate Report
       run: |
         coverage run -m pytest

--- a/pipeline/gtfs/01-validate-gtfs.py
+++ b/pipeline/gtfs/01-validate-gtfs.py
@@ -108,7 +108,7 @@ if PROFILING:
 pre_summ_weekday = time.perf_counter()
 with warnings.catch_warnings():  # slow & triggers warnings, gtfs_kit issue
     warnings.filterwarnings("ignore", category=pd.errors.PerformanceWarning)
-    print(feed.summarise_weekday())
+    print(feed.summarise_days())
 post_summ_weekday = time.perf_counter()
 if PROFILING:
     print(f"summ_weekday in {post_summ_weekday - pre_summ_weekday:0.4f} secs")

--- a/pipeline/gtfs/01-validate-gtfs.py
+++ b/pipeline/gtfs/01-validate-gtfs.py
@@ -12,8 +12,6 @@
 """
 import toml
 from pyprojroot import here
-import warnings
-import pandas as pd
 import time
 import subprocess
 
@@ -106,9 +104,8 @@ if PROFILING:
     print(f"route_modes in {post_route_modes - pre_route_modes:0.4f} seconds")
 
 pre_summ_weekday = time.perf_counter()
-with warnings.catch_warnings():  # slow & triggers warnings, gtfs_kit issue
-    warnings.filterwarnings("ignore", category=pd.errors.PerformanceWarning)
-    print(feed.summarise_days())
+print(feed.summarise_trips())
+print(feed.summarise_routes())
 post_summ_weekday = time.perf_counter()
 if PROFILING:
     print(f"summ_weekday in {post_summ_weekday - pre_summ_weekday:0.4f} secs")

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -274,6 +274,12 @@ class GtfsInstance:
     ) -> pd.DataFrame:
         """Produce a summarised table of route statistics by day of week.
 
+        For route count summaries, func counts route_id only, irrespective of
+        which service_id the routes map to. If the services run on different
+        calendar days, they will be counted separately. In cases where more
+        than one service runs the same route on a day, these will not be
+        counted as distinct routes.
+
         Parameters
         ----------
         summ_ops : list, optional

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -277,7 +277,7 @@ class GtfsInstance:
         For route count summaries, func counts route_id only, irrespective of
         which service_id the routes map to. If the services run on different
         calendar days, they will be counted separately. In cases where more
-        than one service runs the same route on a day, these will not be
+        than one service runs the same route on the same day, these will not be
         counted as distinct routes.
 
         Parameters

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -25,9 +25,9 @@ def _get_intermediate_dates(
     Parameters
     ----------
     start : pd.Timestamp
-        The start date of the given time period
+        The start date of the given time period in %Y%m%d format.
     end : pd.Timestamp
-        The end date of the given time period
+        The end date of the given time period in %Y%m%d format.
 
     Returns
     -------

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -267,11 +267,43 @@ class GtfsInstance:
         except KeyError:
             print("Key Error. Map was not written.")
 
+    def _preprocess_trips_and_routes(self) -> pd.DataFrame:
+        """FILLER DOCSTRING."""
+        # TODO: Fill function
+        # RETURNS THE PRE-PROCESSED TRIPS AND
+        # ROUTES TABLE WITH DATES INCLUDED
+        pass
+
+    def summarise_routes(
+        self,
+        summ_ops: list = [np.min, np.max, np.mean, np.median],
+        return_summary: bool = True,
+    ) -> pd.DataFrame:
+        """FILLER DOCSTRING."""
+        # TODO: Fill function
+        # SUMMARISES THE COUNTS OF ROUTE_ID
+        # FOR EACH DAY (MONDAY, TUESDAY ETC)
+        # OPTIONAL: KEEP NON-AGGREGATED OUTPUTS
+        pass
+
+    def summarise_trips(
+        self,
+        summ_ops: list = [np.min, np.max, np.mean, np.median],
+        return_summary: bool = True,
+    ) -> pd.DataFrame:
+        """FILLER DOCSTRING."""
+        # TODO: Fill function
+        # SUMMARISES THE COUNTS OF ROUTE_ID
+        # FOR EACH DAY (MONDAY, TUESDAY ETC)
+        # OPTIONAL: KEEP NON-AGGREGATED OUTPUTS
+        pass
+
     def summarise_days(
         self,
         summ_ops: list = [np.min, np.max, np.mean, np.median],
         return_summary: bool = True,
     ) -> pd.DataFrame:
+        # TODO: REMOVE FUNCTION WHEN ABOVE(3) FUNCTIONS ARE COMPLETE
         """Produce a summarised table of route statistics by day of week.
 
         For route count summaries, func counts route_id only, irrespective of

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -24,7 +24,7 @@ def _is_path_like(pth, param_nm):
     None
 
     """
-    if not isinstance(pth, (str, pathlib.PosixPath)):
+    if not isinstance(pth, (str, pathlib.Path)):
         raise TypeError(f"`{param_nm}` expected path-like, found {type(pth)}.")
 
 

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -278,7 +278,29 @@ class TestGtfsInstance(object):
             found_cols == exp_cols
         ).all(), f"Expected columns are different. Found: {found_cols}"
 
+    def test__preprocess_trips_and_routes(self, gtfs_fixture):
+        """FILLER DOCSTRING."""
+        # TODO: FILL FUNCTION
+        # THIS INCLUDES CHECKING THE OUTPUTS SCHEMA
+        # AND THE SHAPE USING THE NEWPORT TEST DATA
+        pass
+
+    def test_summarise_trips_defence(self, gtfs_fixture):
+        """FILLER DOCSTRING."""
+        # TODO: FILL FUNCTION SIMILAR TO THE BELOW
+        # TEST_SUMMARISE_DAYS_DEFENCE
+        pass
+
+    def test_summarise_routes_defence(self, gtfs_fixture):
+        """FILLER DOCSTRING."""
+        # TODO: FILL FUNCTION SIMILAR TO THE BELOW
+        # TEST_SUMMARISE_DAYS_DEFENCE
+        pass
+
     def test_summarise_days_defence(self, gtfs_fixture):
+        # TODO: REMOVE THIS FUNCTION ONCE
+        # ITS CONTENTS HAVE BEEN DISTRIBUTED
+        # IN THE ABOVE FUNCTIONS (MOSTLY)
         """Defensive checks for summarise_days()."""
         with pytest.raises(
             TypeError,
@@ -334,6 +356,14 @@ class TestGtfsInstance(object):
         assert fun_out == [
             call("KeyError. Feed was not cleaned.")
         ], f"Expected print statement about KeyError. Found: {fun_out}."
+
+    def test_summarise_trips_on_pass(self, gtfs_fixture):
+        """FILLER DOCSTRING."""
+        pass
+
+    def test_summarise_routes_on_pass(self, gtfs_fixture):
+        """FILLER DOCSTRING."""
+        pass
 
     @pytest.mark.runexpensive
     def test_summarise_days_on_pass(self, gtfs_fixture):

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -279,7 +279,7 @@ class TestGtfsInstance(object):
         ).all(), f"Expected columns are different. Found: {found_cols}"
 
     def test_summarise_days_defence(self, gtfs_fixture):
-        """Defensive checks for summarise_weekday()."""
+        """Defensive checks for summarise_days()."""
         with pytest.raises(
             TypeError,
             match="Each item in `summ_ops`.*. Found <class 'str'> : np.mean",


### PR DESCRIPTION
## Description
This PR changes the overall method for obtaining the number of routes that run on a given day, separated by route type. This includes a raw table containing the number of routes operating on a specific day (e.g., 2021-01-01) and also an aggregated version of this table including the average number of routes on each day of the week (e.g., Monday).

Fixes #23
## Motivation and Context
Adds further functionality to the daily summaries, along with a more performant method. Also removes warnings generated by the pre-existing method.

## Type of change
<!--- Please select from the options below --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Windows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: conda/pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
N/A
