### PR TITLE
Adjust check_parent_dir_exists() to fix bugs

### DIFF
--- a/pipeline/gtfs/01-validate-gtfs.py
+++ b/pipeline/gtfs/01-validate-gtfs.py
@@ -84,14 +84,19 @@ except AttributeError:
 
 # visualise gtfs
 pre_viz_points = time.perf_counter()
-feed.viz_stops(out_pth=POINT_MAP_PTH)
+feed.viz_stops(out_pth=POINT_MAP_PTH, create_out_parent=True)
 post_viz_points = time.perf_counter()
 if PROFILING:
     print(f"viz_points in {post_viz_points - pre_viz_points:0.4f} seconds")
 print(f"Map written to {POINT_MAP_PTH}")
 
 pre_viz_hull = time.perf_counter()
-feed.viz_stops(out_pth=HULL_MAP_PATH, geoms="hull", geom_crs=GEOM_CRS)
+feed.viz_stops(
+    out_pth=HULL_MAP_PATH,
+    geoms="hull",
+    geom_crs=GEOM_CRS,
+    create_out_parent=True,
+)
 post_viz_hull = time.perf_counter()
 if PROFILING:
     print(f"viz_hull in {post_viz_hull - pre_viz_hull:0.4f} seconds")

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -35,7 +35,7 @@ def _check_parent_dir_exists(pth, param_nm, create=False):
     parent = os.path.dirname(pth)
     if not os.path.exists(parent):
         if create:
-            os.mkdir(parent)
+            os.makedirs(parent)
             print(f"Creating parent directory: {parent}")
         else:
             raise FileNotFoundError(

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -32,7 +32,6 @@ def _check_parent_dir_exists(pth, param_nm, create=False):
     _is_path_like(pth, param_nm)
     # replace back slashes to ensure consistency
     pth = pth.replace("\\", "/").replace(repr("\\"), "").replace("'", "")
-    pth = pth.replace("\\", "/")
     # convert path to the correct OS specific format
     pth = pathlib.Path(pth)
     # realpath helps to catch cases where relative paths are passed in main

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -30,6 +30,8 @@ def _is_path_like(pth, param_nm):
 
 def _check_parent_dir_exists(pth, param_nm, create=False):
     _is_path_like(pth, param_nm)
+    # convert path to the correct OS specific format
+    pth = pathlib.Path(pth)
     # realpath helps to catch cases where relative paths are passed in main
     pth = os.path.realpath(pth)
     parent = os.path.dirname(pth)

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -2,10 +2,14 @@
 import pathlib
 import numpy as np
 import os
+from typing import Union
 
 
 def _is_path_like(pth, param_nm):
     """Handle path-like parameter values.
+
+    It is important to note that paths including backslashes are not accepted,
+    with forward slashes being the only option.
 
     Parameters
     ----------
@@ -27,11 +31,49 @@ def _is_path_like(pth, param_nm):
     if not isinstance(pth, (str, pathlib.Path)):
         raise TypeError(f"`{param_nm}` expected path-like, found {type(pth)}.")
 
+    if not isinstance(pth, pathlib.Path):
+        if "\\" in repr(pth):
+            raise ValueError(
+                "Please specify string paths with single forward"
+                " slashes only."
+                f" Got {repr(pth)}"
+            )
 
-def _check_parent_dir_exists(pth, param_nm, create=False):
+
+def _check_parent_dir_exists(
+    pth: Union[str, pathlib.Path], param_nm: str, create: bool = False
+) -> None:
+    """Check if a files parent directory exists.
+
+    The parent directory in this case will be the second layer. If only a
+    single layer is passed, the parent directory will be assumed to exist as
+    it will be the current working directory.
+
+    Parameters
+    ----------
+    pth : Union[str, pathlib.Path]
+        The path to the file who's parent dir is being confirmed to exist. The
+        function will consider the second layer of the path to be the parent
+        directory.
+    param_nm : str
+        The name of the parameter for the path. This is used in the error
+        message within is_path_like()
+    create : bool, optional
+        Whether or not to create the parent directory if it does not already
+        exist, by default False
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    FileNotFoundError
+        An error is raised if the parent directory could not be found and also
+        the create parameter is False.
+
+    """
     _is_path_like(pth, param_nm)
-    # replace back slashes to ensure consistency
-    pth = str(pth).replace("\\", "/").replace(repr("\\"), "").replace("'", "")
     # convert path to the correct OS specific format
     pth = pathlib.Path(pth)
     # realpath helps to catch cases where relative paths are passed in main

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -31,7 +31,7 @@ def _is_path_like(pth, param_nm):
 def _check_parent_dir_exists(pth, param_nm, create=False):
     _is_path_like(pth, param_nm)
     # replace back slashes to ensure consistency
-    pth = pth.replace("\\", "/").replace(repr("\\"), "").replace("'", "")
+    pth = str(pth).replace("\\", "/").replace(repr("\\"), "").replace("'", "")
     # convert path to the correct OS specific format
     pth = pathlib.Path(pth)
     # realpath helps to catch cases where relative paths are passed in main

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -30,10 +30,13 @@ def _is_path_like(pth, param_nm):
 
 def _check_parent_dir_exists(pth, param_nm, create=False):
     _is_path_like(pth, param_nm)
-    # realpath helps to catch cases where relative paths are passed in main
-    pth = os.path.realpath(pth)
+    # replace back slashes to ensure consistency
+    pth = pth.replace("\\", "/").replace(repr("\\"), "").replace("'", "")
+    pth = pth.replace("\\", "/")
     # convert path to the correct OS specific format
     pth = pathlib.Path(pth)
+    # realpath helps to catch cases where relative paths are passed in main
+    pth = os.path.realpath(pth)
     parent = os.path.dirname(pth)
     if not os.path.exists(parent):
         if create:

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -30,10 +30,10 @@ def _is_path_like(pth, param_nm):
 
 def _check_parent_dir_exists(pth, param_nm, create=False):
     _is_path_like(pth, param_nm)
-    # convert path to the correct OS specific format
-    pth = pathlib.Path(pth)
     # realpath helps to catch cases where relative paths are passed in main
     pth = os.path.realpath(pth)
+    # convert path to the correct OS specific format
+    pth = pathlib.Path(pth)
     parent = os.path.dirname(pth)
     if not os.path.exists(parent):
         if create:

--- a/tests/gtfs/test_gtfs_utils.py
+++ b/tests/gtfs/test_gtfs_utils.py
@@ -3,6 +3,7 @@
 from pyprojroot import here
 import os
 import pytest
+import pathlib
 
 from transport_performance.gtfs.gtfs_utils import bbox_filter_gtfs
 from transport_performance.gtfs.validation import GtfsInstance
@@ -23,7 +24,7 @@ class TestBboxFilterGtfs(object):
         tmp_out = os.path.join(tmpdir, "newport-train-station_gtfs.zip")
         bbox_filter_gtfs(
             in_pth=here("tests/data/newport-20230613_gtfs.zip"),
-            out_pth=tmp_out,
+            out_pth=pathlib.Path(tmp_out),
             bbox_list=[
                 -3.0017783334,
                 51.5874718209,
@@ -35,7 +36,7 @@ class TestBboxFilterGtfs(object):
             tmp_out
         ), f"Expected {tmp_out} to exist but it did not."
         # check the output gtfs can be read
-        feed = GtfsInstance(gtfs_pth=tmp_out)
+        feed = GtfsInstance(gtfs_pth=pathlib.Path(tmp_out))
         assert isinstance(
             feed, GtfsInstance
         ), f"Expected class `Gtfs_Instance but found: {type(feed)}`"

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -8,6 +8,7 @@ import os
 from geopandas import GeoDataFrame
 import numpy as np
 import re
+import pathlib
 
 from transport_performance.gtfs.validation import (
     GtfsInstance,
@@ -172,19 +173,21 @@ class TestGtfsInstance(object):
     def test_viz_stops_point(self, mock_print, tmpdir, gtfs_fixture):
         """Check behaviour of viz_stops when plotting point geom."""
         tmp = os.path.join(tmpdir, "points.html")
-        gtfs_fixture.viz_stops(out_pth=tmp)
+        gtfs_fixture.viz_stops(out_pth=pathlib.Path(tmp))
         assert os.path.exists(
             tmp
         ), f"{tmp} was expected to exist but it was not found."
         # check behaviour when parent directory doesn't exist
         no_parent_pth = os.path.join(tmpdir, "notfound", "points1.html")
-        gtfs_fixture.viz_stops(out_pth=no_parent_pth, create_out_parent=True)
+        gtfs_fixture.viz_stops(
+            out_pth=pathlib.Path(no_parent_pth), create_out_parent=True
+        )
         assert os.path.exists(
             no_parent_pth
         ), f"{no_parent_pth} was expected to exist but it was not found."
         # check behaviour when not implemented fileext used
         tmp1 = os.path.join(tmpdir, "points2.svg")
-        gtfs_fixture.viz_stops(out_pth=tmp1)
+        gtfs_fixture.viz_stops(out_pth=pathlib.Path(tmp1))
         # need to use regex for the first print statement, as tmpdir will
         # change.
         start_pat = re.compile(r"Creating parent directory:.*")
@@ -204,7 +207,7 @@ class TestGtfsInstance(object):
     def test_viz_stops_hull(self, tmpdir, gtfs_fixture):
         """Check viz_stops behaviour when plotting hull geom."""
         tmp = os.path.join(tmpdir, "hull.html")
-        gtfs_fixture.viz_stops(out_pth=tmp, geoms="hull")
+        gtfs_fixture.viz_stops(out_pth=pathlib.Path(tmp), geoms="hull")
         assert os.path.exists(
             tmp
         ), f"Map should have been written to {tmp} but was not found."

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -121,5 +121,5 @@ class Test_CheckParentDirExists(object):
 
         assert os.path.exists(os.path.join(tmp_path, "test_dir_bs")), (
             "_check_parent_dir_exists did not make parent dir"
-            " when 'create=True' (multiple levels)"
+            " with escaped backslashes in the path"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -119,7 +119,7 @@ class Test_CheckParentDirExists(object):
             create=True,
         )
 
-        assert os.path.exists(os.path.join(tmp_path, "test_dir_bs")), (
+        assert os.path.exists(pathlib.Path(tmp_path + "/test_dir_bs")), (
             "_check_parent_dir_exists did not make parent dir"
             " with escaped backslashes in the path"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -118,7 +118,7 @@ class Test_CheckParentDirExists(object):
             create=True,
         )
 
-        assert os.path.exists(f"{tmp_path}/test_dir_bs"), (
+        assert os.path.exists(os.path.join(tmp_path, "test_dir_bs")), (
             "_check_parent_dir_exists did not make parent dir"
             " with escaped backslashes in the path"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -1,6 +1,7 @@
 """Tests for defence.py. These internals may be covered elsewhere."""
 import re
 import os
+import pathlib
 
 import pytest
 
@@ -85,12 +86,12 @@ class Test_CheckParentDirExists(object):
 
         # test creating the parent directory (1 level)
         _check_parent_dir_exists(
-            pth=os.path.join(tmp_path, "test_dir", "test_dir.html"),
+            pth=os.path.join(tmp_path, "test_dir_single", "test.html"),
             param_nm="test_prm",
             create=True,
         )
 
-        assert os.path.exists(os.path.join(tmp_path, "test_dir")), (
+        assert os.path.exists(os.path.join(tmp_path, "test_dir_single")), (
             "_check_parent_dir_exists did not make parent dir"
             " when 'create=True' (single level)"
         )
@@ -98,15 +99,27 @@ class Test_CheckParentDirExists(object):
         # test creating the parent directory (2 levels)
         _check_parent_dir_exists(
             pth=os.path.join(
-                tmp_path, "test_dir", "test_dir", "test_dir.html"
+                tmp_path, "test_dir_multi", "test_dir_multi", "test.html"
             ),
             param_nm="test_prm",
             create=True,
         )
 
         assert os.path.exists(
-            os.path.join(tmp_path, "test_dir", "test_dir")
+            os.path.join(tmp_path, "test_dir_multi", "test_dir_multi")
         ), (
+            "_check_parent_dir_exists did not make parent dir"
+            " when 'create=True' (multiple levels)"
+        )
+
+        # test creating a directory with backslash characters in the name
+        _check_parent_dir_exists(
+            pth=pathlib.Path(f"{tmp_path}\\test_dir_bs\\test.html"),
+            param_nm="test_prm",
+            create=True,
+        )
+
+        assert os.path.exists(os.path.join(tmp_path, "test_dir_bs")), (
             "_check_parent_dir_exists did not make parent dir"
             " when 'create=True' (multiple levels)"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -1,6 +1,7 @@
 """Tests for defence.py. These internals may be covered elsewhere."""
 import re
 import os
+import pathlib
 
 import pytest
 
@@ -64,6 +65,21 @@ class Test_CheckParentDirExists(object):
                 pth="missing/file.someext", param_nm="not_found", create=False
             )
 
+        error_pth = "test_folder\\test_file.py"
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Please specify string paths with single forward"
+                " slashes only."
+                f" Got {repr(error_pth)}"
+            ),
+        ):
+            _check_parent_dir_exists(
+                pth="test_folder\\test_file.py",
+                param_nm="test_prm",
+                create=False,
+            )
+
     def test_check_parents_dir_exists(self, tmp_path):
         """Test that a parent directory is created."""
         # test without create
@@ -76,8 +92,10 @@ class Test_CheckParentDirExists(object):
             ),
         ):
             _check_parent_dir_exists(
-                pth=os.path.join(
-                    tmp_path, "data_path", "data_path", "test.html"
+                pth=pathlib.Path(
+                    os.path.join(
+                        tmp_path, "data_path", "data_path", "test.html"
+                    )
                 ),
                 param_nm="test_prm",
                 create=False,
@@ -85,40 +103,36 @@ class Test_CheckParentDirExists(object):
 
         # test creating the parent directory (1 level)
         _check_parent_dir_exists(
-            pth=os.path.join(tmp_path, "test_dir_single", "test.html"),
-            param_nm="test_prm",
-            create=True,
-        )
-
-        assert os.path.exists(os.path.join(tmp_path, "test_dir_single")), (
-            "_check_parent_dir_exists did not make parent dir"
-            " when 'create=True' (single level)"
-        )
-
-        # test creating the parent directory (2 levels)
-        _check_parent_dir_exists(
-            pth=os.path.join(
-                tmp_path, "test_dir_multi", "test_dir_multi", "test.html"
+            pth=pathlib.Path(
+                os.path.join(tmp_path, "test_dir_single", "test.html")
             ),
             param_nm="test_prm",
             create=True,
         )
 
         assert os.path.exists(
-            os.path.join(tmp_path, "test_dir_multi", "test_dir_multi")
+            pathlib.Path(os.path.join(tmp_path, "test_dir_single"))
         ), (
             "_check_parent_dir_exists did not make parent dir"
-            " when 'create=True' (multiple levels)"
+            " when 'create=True' (single level)"
         )
 
-        # test creating a directory with backslash characters in the name
+        # test creating the parent directory (2 levels)
         _check_parent_dir_exists(
-            pth=f"{tmp_path}\\test_dir_bs\\test.html",
+            pth=pathlib.Path(
+                os.path.join(
+                    tmp_path, "test_dir_multi", "test_dir_multi", "test.html"
+                )
+            ),
             param_nm="test_prm",
             create=True,
         )
 
-        assert os.path.exists(os.path.join(tmp_path, "test_dir_bs")), (
+        assert os.path.exists(
+            pathlib.Path(
+                os.path.join(tmp_path, "test_dir_multi", "test_dir_multi")
+            )
+        ), (
             "_check_parent_dir_exists did not make parent dir"
-            " with escaped backslashes in the path"
+            " when 'create=True' (multiple levels)"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -119,7 +119,7 @@ class Test_CheckParentDirExists(object):
             create=True,
         )
 
-        assert os.path.exists(pathlib.Path(tmp_path + "/test_dir_bs")), (
+        assert os.path.exists(pathlib.Path(f"{tmp_path}/test_dir_bs")), (
             "_check_parent_dir_exists did not make parent dir"
             " with escaped backslashes in the path"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -1,10 +1,8 @@
 """Tests for defence.py. These internals may be covered elsewhere."""
 import re
 import os
-import shutil
 
 import pytest
-from pyprojroot import here
 
 from transport_performance.utils.defence import (
     _check_list,
@@ -66,46 +64,49 @@ class Test_CheckParentDirExists(object):
                 pth="missing/file.someext", param_nm="not_found", create=False
             )
 
-    def test_check_parents_dir_exists(self):
+    def test_check_parents_dir_exists(self, tmp_path):
         """Test that a parent directory is created."""
         # test without create
+        expected_error_path = os.path.join(tmp_path, "data_path", "data_path")
         with pytest.raises(
             FileNotFoundError,
             match=re.escape(
-                "Parent directory D:\\DSC\\transport-network-performance"
-                "\\data\\interim\\test_dir not found on disk"
+                rf"Parent directory {expected_error_path}"
+                r" not found on disk."
             ),
         ):
             _check_parent_dir_exists(
-                pth="data/interim/test_dir/test_dir.html",
+                pth=os.path.join(
+                    tmp_path, "data_path", "data_path", "test.html"
+                ),
                 param_nm="test_prm",
                 create=False,
             )
 
         # test creating the parent directory (1 level)
         _check_parent_dir_exists(
-            pth="data/interim/test_dir/test_dir.html",
+            pth=os.path.join(tmp_path, "test_dir", "test_dir.html"),
             param_nm="test_prm",
             create=True,
         )
 
-        assert os.path.exists(here("data/interim/test_dir/")), (
+        assert os.path.exists(os.path.join(tmp_path, "test_dir")), (
             "_check_parent_dir_exists did not make parent dir"
-            "when 'create=True' (single level)"
+            " when 'create=True' (single level)"
         )
-
-        shutil.rmtree("data/interim/test_dir/")
 
         # test creating the parent directory (2 levels)
         _check_parent_dir_exists(
-            pth="data/interim/test_dir/test_dir/test_dir.html",
+            pth=os.path.join(
+                tmp_path, "test_dir", "test_dir", "test_dir.html"
+            ),
             param_nm="test_prm",
             create=True,
         )
 
-        assert os.path.exists(here("data/interim/test_dir/test_dir/")), (
+        assert os.path.exists(
+            os.path.join(tmp_path, "test_dir", "test_dir")
+        ), (
             "_check_parent_dir_exists did not make parent dir"
-            "when 'create=True' (multiple levels)"
+            " when 'create=True' (multiple levels)"
         )
-
-        shutil.rmtree("data/interim/test_dir")

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -1,7 +1,6 @@
 """Tests for defence.py. These internals may be covered elsewhere."""
 import re
 import os
-import pathlib
 
 import pytest
 
@@ -114,12 +113,12 @@ class Test_CheckParentDirExists(object):
 
         # test creating a directory with backslash characters in the name
         _check_parent_dir_exists(
-            pth=pathlib.Path(f"{tmp_path}\\test_dir_bs\\test.html"),
+            pth=f"{tmp_path}\\test_dir_bs\\test.html",
             param_nm="test_prm",
             create=True,
         )
 
-        assert os.path.exists(pathlib.Path(f"{tmp_path}/test_dir_bs")), (
+        assert os.path.exists(f"{tmp_path}/test_dir_bs"), (
             "_check_parent_dir_exists did not make parent dir"
             " with escaped backslashes in the path"
         )

--- a/tests/utils/test_defence.py
+++ b/tests/utils/test_defence.py
@@ -1,5 +1,10 @@
 """Tests for defence.py. These internals may be covered elsewhere."""
+import re
+import os
+import shutil
+
 import pytest
+from pyprojroot import here
 
 from transport_performance.utils.defence import (
     _check_list,
@@ -60,3 +65,47 @@ class Test_CheckParentDirExists(object):
             _check_parent_dir_exists(
                 pth="missing/file.someext", param_nm="not_found", create=False
             )
+
+    def test_check_parents_dir_exists(self):
+        """Test that a parent directory is created."""
+        # test without create
+        with pytest.raises(
+            FileNotFoundError,
+            match=re.escape(
+                "Parent directory D:\\DSC\\transport-network-performance"
+                "\\data\\interim\\test_dir not found on disk"
+            ),
+        ):
+            _check_parent_dir_exists(
+                pth="data/interim/test_dir/test_dir.html",
+                param_nm="test_prm",
+                create=False,
+            )
+
+        # test creating the parent directory (1 level)
+        _check_parent_dir_exists(
+            pth="data/interim/test_dir/test_dir.html",
+            param_nm="test_prm",
+            create=True,
+        )
+
+        assert os.path.exists(here("data/interim/test_dir/")), (
+            "_check_parent_dir_exists did not make parent dir"
+            "when 'create=True' (single level)"
+        )
+
+        shutil.rmtree("data/interim/test_dir/")
+
+        # test creating the parent directory (2 levels)
+        _check_parent_dir_exists(
+            pth="data/interim/test_dir/test_dir/test_dir.html",
+            param_nm="test_prm",
+            create=True,
+        )
+
+        assert os.path.exists(here("data/interim/test_dir/test_dir/")), (
+            "_check_parent_dir_exists did not make parent dir"
+            "when 'create=True' (multiple levels)"
+        )
+
+        shutil.rmtree("data/interim/test_dir")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->

Fixes #60 
Fixes #61

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
The motivation behind this PR is to address bugs introduced in the `_check_parent_dir_exists()` function
in src/transport_preformance/utils/defences.py. 

## Type of change
<!--- Please select from the options below --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->
I have used unit tests to ensure that directories are being successfully created. This includes creating single parent directories and also multiple parent directories.  
Tests have also been completed to ensure that when `create=False` in `_check_parent_dir_exists()`, an error is thrown if the parent directory does not already exist.  
Further tests have been created to ensure that file paths including any number of '\' characters are processed correctly through converting to forward slash and then converting into an os specific path object.  
These tests were completed on both Windows and macOS.


Test configuration details:
Test 1:  
* OS: Windows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: Conda

Test 2:  
* OS: macOS Big Sur 11.6
* Python version: 3.9.13
* Java version: N/A
* Python management system: virtualenv

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->
'macOS' tests were completed on my personal machine (off network, non work related).  
Also, github actions passed the tests on both Ubuntu and MacOS.
## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
