### PR TITLE
84 path warning

### DIFF
--- a/notebooks/urban_centres/poc_urban_centres.py
+++ b/notebooks/urban_centres/poc_urban_centres.py
@@ -163,7 +163,7 @@ bbox_mrs = gpd.GeoDataFrame(index=[0], crs="epsg:4326", geometry=[box(*BBOX)])
 bbox_mrs_r = bbox_mrs.to_crs("esri:54009")
 
 # bbox centroid
-bbox_mrs_centroid = bbox_mrs.to_crs("epsg:27700").centroid.to_crs("epsg:4326")
+bbox_mrs_centroid = bbox_mrs_r.centroid.to_crs("epsg:4326")
 coords = (bbox_mrs_centroid.y[0], bbox_mrs_centroid.x[0])
 
 # pop only criteria

--- a/notebooks/urban_centres/poc_urban_centres.py
+++ b/notebooks/urban_centres/poc_urban_centres.py
@@ -84,9 +84,13 @@ BBOX_DICT = {
 AREA_OF_INTEREST = "newport"
 BBOX = BBOX_DICT[AREA_OF_INTEREST]
 
+# bbox
 bbox_npt = gpd.GeoDataFrame(index=[0], crs="epsg:4326", geometry=[box(*BBOX)])
 bbox_npt_r = bbox_npt.to_crs("esri:54009")
-coords = (float(bbox_npt.centroid.y), float(bbox_npt.centroid.x))
+
+# bbox centroid
+bbox_npt_centroid = bbox_npt.to_crs("epsg:27700").centroid.to_crs("epsg:4326")
+coords = (bbox_npt_centroid.y[0], bbox_npt_centroid.x[0])
 
 # pop only criteria
 npt = ucc.UrbanCentre(file=(MERGED_DIR))
@@ -105,9 +109,13 @@ m
 AREA_OF_INTEREST = "leeds"
 BBOX = BBOX_DICT[AREA_OF_INTEREST]
 
+# bbox
 bbox_lds = gpd.GeoDataFrame(index=[0], crs="epsg:4326", geometry=[box(*BBOX)])
 bbox_lds_r = bbox_lds.to_crs("esri:54009")
-coords = (float(bbox_lds.centroid.y), float(bbox_lds.centroid.x))
+
+# bbox centroid
+bbox_lds_centroid = bbox_lds.to_crs("epsg:27700").centroid.to_crs("epsg:4326")
+coords = (bbox_lds_centroid.y[0], bbox_lds_centroid.x[0])
 
 # pop only criteria
 lds = ucc.UrbanCentre(file=(MERGED_DIR))
@@ -126,9 +134,13 @@ m
 AREA_OF_INTEREST = "london"
 BBOX = BBOX_DICT[AREA_OF_INTEREST]
 
+# bbox
 bbox_lnd = gpd.GeoDataFrame(index=[0], crs="epsg:4326", geometry=[box(*BBOX)])
 bbox_lnd_r = bbox_lnd.to_crs("esri:54009")
-coords = (float(bbox_lnd.centroid.y), float(bbox_lnd.centroid.x))
+
+# bbox centroid
+bbox_lnd_centroid = bbox_lnd.to_crs("epsg:27700").centroid.to_crs("epsg:4326")
+coords = (bbox_lnd_centroid.y[0], bbox_lnd_centroid.x[0])
 
 # pop only criteria
 lnd = ucc.UrbanCentre(file=(MERGED_DIR))
@@ -146,9 +158,13 @@ m
 AREA_OF_INTEREST = "marseille"
 BBOX = BBOX_DICT[AREA_OF_INTEREST]
 
+# bbox
 bbox_mrs = gpd.GeoDataFrame(index=[0], crs="epsg:4326", geometry=[box(*BBOX)])
 bbox_mrs_r = bbox_mrs.to_crs("esri:54009")
-coords = (float(bbox_mrs.centroid.y), float(bbox_mrs.centroid.x))
+
+# bbox centroid
+bbox_mrs_centroid = bbox_mrs.to_crs("epsg:27700").centroid.to_crs("epsg:4326")
+coords = (bbox_mrs_centroid.y[0], bbox_mrs_centroid.x[0])
 
 # pop only criteria
 mrs = ucc.UrbanCentre(file=(MERGED_DIR))

--- a/src/transport_performance/urban_centres/raster_uc.py
+++ b/src/transport_performance/urban_centres/raster_uc.py
@@ -360,7 +360,7 @@ class UrbanCentre:
         if not (5 <= threshold <= 8):
             raise ValueError(
                 "Wrong value for `threshold`, "
-                "please enter value between 1 and 9"
+                "please enter value between 5 and 8"
             )
 
         filled = urban_centres.copy()

--- a/src/transport_performance/urban_centres/raster_uc.py
+++ b/src/transport_performance/urban_centres/raster_uc.py
@@ -14,12 +14,16 @@ from pyproj import Transformer
 from rasterio.mask import raster_geometry_mask
 from rasterio.transform import rowcol
 from scipy.ndimage import generic_filter, label
+from transport_performance.utils.defence import _is_path_like
 
 
 class UrbanCentre:
     """Create urban centre object."""
 
     def __init__(self, file):
+
+        # check that path is str or PosixPath
+        _is_path_like(file, "filepath")
         self.file = file
 
     def get_urban_centre(
@@ -126,10 +130,6 @@ class UrbanCentre:
             tuple[2]: crs string from the raster.
 
         """
-        if not isinstance(file, str):
-            raise TypeError(
-                "`file` expected string, " f"got {type(file).__name__}."
-            )
         if not isinstance(bbox, gpd.GeoDataFrame):
             raise TypeError(
                 "`bbox` expected GeoDataFrame, " f"got {type(bbox).__name__}."

--- a/src/transport_performance/urban_centres/raster_uc.py
+++ b/src/transport_performance/urban_centres/raster_uc.py
@@ -341,7 +341,7 @@ class UrbanCentre:
         threshold: int
             If the number of cells adjacent to any empty cell belonging to
             a cluster is higher than the threshold, the cell is filled with
-            the cluster value.
+            the cluster value.  Needs to be between 5 and 8.
 
         Returns
         -------
@@ -358,7 +358,7 @@ class UrbanCentre:
                 "`threshold` expected integer, "
                 f"got {type(threshold).__name__}"
             )
-        if not (1 <= threshold <= 9):
+        if not (5 <= threshold <= 8):
             raise ValueError(
                 "Wrong value for `threshold`, "
                 "please enter value between 1 and 9"

--- a/src/transport_performance/urban_centres/raster_uc.py
+++ b/src/transport_performance/urban_centres/raster_uc.py
@@ -282,7 +282,6 @@ class UrbanCentre:
         urban_centres = labelled_array.copy()
         for n in range(1, num_clusters + 1):
             total_pop = ma.sum(ma.masked_where(urban_centres != n, band))
-            # print(n, total_pop)
 
             if total_pop < cluster_pop_threshold:
                 urban_centres[urban_centres == n] = 0
@@ -377,7 +376,6 @@ class UrbanCentre:
                 extra_keywords={"threshold": threshold},
             )
             if np.array_equal(filled, check):
-                # print("iter", n)
                 break
         return filled
 

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -13,6 +13,7 @@ import pytest
 import rasterio as rio
 
 from contextlib import nullcontext as does_not_raise
+from pathlib import Path
 from pytest_lazyfixture import lazy_fixture
 from shapely.geometry import Polygon
 
@@ -141,14 +142,19 @@ def outside_cluster_centre():
 
 # test exceptions for input parameters
 @pytest.mark.parametrize(
-    "filepath, expected",
+    "filepath, func, expected",
     [
-        (lazy_fixture("dummy_pop_array"), does_not_raise()),
-        ("wrongpath", pytest.raises(IOError)),
+        (lazy_fixture("dummy_pop_array"), "str", does_not_raise()),
+        (lazy_fixture("dummy_pop_array"), "path", does_not_raise()),
+        ("wrongpath", "str", pytest.raises(IOError)),
     ],
 )
-def test_file(filepath, bbox, cluster_centre, expected):
+def test_file(filepath, func, bbox, cluster_centre, expected):
     """Test filepath."""
+    if func == "str":
+        filepath = str(filepath)
+    elif func == "str":
+        filepath = Path(filepath)
     with expected:
         assert (
             ucc.UrbanCentre(filepath).get_urban_centre(bbox, cluster_centre)

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -153,7 +153,7 @@ def test_file(filepath, func, bbox, cluster_centre, expected):
     """Test filepath."""
     if func == "str":
         filepath = str(filepath)
-    elif func == "str":
+    else:
         filepath = Path(filepath)
     with expected:
         assert (


### PR DESCRIPTION
## Description
Fixes #84
Fixes #88 
Fixes #89

## Motivation and Context
Fixes issue where `pathlib.Path` objects would not be accepted as inputs for class `UrbanCentre`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested by running `notebooks/urban_centres/poc_urban_centres.py` and passing the string paths to `pathlib.Path`.

Modified `tests/urban_centres/test_urban_centres.py` to check for both `str` and `pathlib.Path` objects.

Test configuration details:
* OS: macOS Ventura 13.4.1(c)
* Python version: 3.9.13
* Java version:
* Python management system: conda/pip

## Advice for reviewer
Fixed a few very small technical debt issues within `UrbanCentre`.

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional comments
When running `notebooks/urban_centres/poc_urban_centres.py` two warnings were raised:
- UserWarning from GeoPandas for using a non-projected crs to calculate centroids.
- FutureWarning from Pandas for calling float on a series with a single element (to be deprecated).

I refactored the code to prevent these.
