### PR TITLE
Added temp dir to `test_viz_stops_defence`

### DIFF
--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -137,8 +137,9 @@ class TestGtfsInstance(object):
         ], f"Expected print statements about GTFS warnings. Found: {fun_out}"
 
     @patch("builtins.print")
-    def test_viz_stops_defence(self, mocked_print, gtfs_fixture):
+    def test_viz_stops_defence(self, mocked_print, tmpdir, gtfs_fixture):
         """Check defensive behaviours of viz_stops()."""
+        tmp = os.path.join(tmpdir, "somefile.html")
         with pytest.raises(
             TypeError,
             match="`out_pth` expected path-like, found <class 'bool'>",
@@ -147,23 +148,19 @@ class TestGtfsInstance(object):
         with pytest.raises(
             TypeError, match="`geoms` expects a string. Found <class 'int'>"
         ):
-            gtfs_fixture.viz_stops(out_pth="outputs/somefile.html", geoms=38)
+            gtfs_fixture.viz_stops(out_pth=tmp, geoms=38)
         with pytest.raises(
             ValueError, match="`geoms` must be either 'point' or 'hull."
         ):
-            gtfs_fixture.viz_stops(
-                out_pth="outputs/somefile.html", geoms="foobar"
-            )
+            gtfs_fixture.viz_stops(out_pth=tmp, geoms="foobar")
         with pytest.raises(
             TypeError,
             match="`geom_crs`.*string or integer. Found <class 'float'>",
         ):
-            gtfs_fixture.viz_stops(
-                out_pth="outputs/somefile.html", geom_crs=1.1
-            )
+            gtfs_fixture.viz_stops(out_pth=tmp, geom_crs=1.1)
         # check missing stop_id results in print instead of exception
         gtfs_fixture.feed.stops.drop("stop_id", axis=1, inplace=True)
-        gtfs_fixture.viz_stops(out_pth="outputs/out.html")
+        gtfs_fixture.viz_stops(out_pth=tmp)
         fun_out = mocked_print.mock_calls
         assert fun_out == [
             call("Key Error. Map was not written.")


### PR DESCRIPTION
## Description
Fixes #106 

## Motivation and Context
Fixes test `test_viz_stops_defence` not using temp directory.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Run test locally from root directory and from file directory.

Test configuration details:
* OS: macOS Ventura
* Python version: 3.9.13
* Java version:
* Python management system: conda/pip

## Advice for reviewer


## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional comments

