### PR TITLE
52 pop plot no uc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pre-commit
 r5py>=0.0.4
 gtfs_kit==5.2.7
 rasterio
-matplotlib
+matplotlib>=3.7.0
 scipy
 rioxarray
 geopandas

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -464,18 +464,30 @@ class RasterPop:
         )
 
         # add the centroids to a separate layer
-        self.centroid_gdf.explore(
-            self.__UC_COL_NAME,
-            name="Centroids",
-            m=m,
-            show=False,
-            style_kwds={
+        # conditionally style plot based on whether UC is provided
+        if self._uc_gdf is not None:
+            centroid_plot_col = self.__UC_COL_NAME
+            # this dict will change the centriod color in/out the UC.
+            centroid_style_dict = {
                 "style_function": lambda x: {
                     "color": "#BC544B"
                     if x["properties"][self.__UC_COL_NAME] is False
                     else "#8B0000"
                 }
-            },
+            }
+        else:
+            centroid_plot_col = None
+            centroid_style_dict = {
+                "style_function": lambda x: {"color": "#BC544B"}
+            }
+
+        # add in the centroid layer with the conditional styling
+        self.centroid_gdf.explore(
+            centroid_plot_col,
+            name="Centroids",
+            m=m,
+            show=False,
+            style_kwds=centroid_style_dict,
             legend=False,
         )
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -34,7 +34,7 @@ class RasterPop:
     pop_gdf : gpd.GeoDataFrame
         A geopandas dataframe of the input data, with gridded geometry. This is
         in the same CRS as the input raster data.
-    centroid_gdf
+    centroid_gdf : gpd.GeoDataFrame
         A geopandas dataframe of grid centroids, converted to EPSG:4326 for
         transport analysis.
 
@@ -153,7 +153,7 @@ class RasterPop:
         save : str, optional
             Filepath to save file, with the file extension, by default None
             meaning a file will not be saved.
-        **kwargs
+        kwargs : dict, optional
             Extra arguments passed to plotting functions to configure the plot
             styling. See Notes for more support.
 
@@ -177,9 +177,10 @@ class RasterPop:
         -----
         Calling `help` as follows will provide more insights on possible kwarg
         arguments for the valid plotting backends:
-            - Folium backend: `help(RasterPop._plot_folium)
-            - Matplotlib backend: `help(RasterPop._plot_matplotlib)
-            - Cartopy backend: `help(RasterPop._plot_cartopy)
+
+        - Folium backend: `help(RasterPop._plot_folium)`
+        - Matplotlib backend: `help(RasterPop._plot_matplotlib)`
+        - Cartopy backend: `help(RasterPop._plot_cartopy)`
 
         """
         # record of valid which values


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Bug fix to resolve issue with generating population `folium` plots without an urban centre. Fixes #52 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
Fixing the bug so that `folium` population plots can be built without defining an urban centre

## Type of change
<!--- Please select from the options below --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->
Tested locally with and without an urban centre. `AttributeError` no longer raised, and the expected plots are returned (no urban centre when one isn't provided). The fix has had no impact on the original functionality (checked that providing and urban centre still works too). No unit tests yet for `RasterPop` plotting function, see #57. Linking this PR back to that issue so that one will be added when the tech-debt is re-payed.

Test configuration details:
* OS: macOS
* Python version: 3.9.13
* Java version: 11
* Python management system: conda/pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

Cherry-picked commit d385bd4 into this branch in advance. This brings in docstring changes into `RasterPop`, that were made in `105-setup-sphinx` to check restructured text parsing inside docstrings. This was done so that these docstring changes do not influence the `105-setup-sphinx` PR by changing the line numbers, and vice versa. This way, both open PRs can be reviewed in any order without introducing a merge conflict.

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
None
