### PR TITLE
25 pytest mark behaviour

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -41,28 +41,37 @@ def pytest_configure(config):
     )
 
 
-def pytest_collection_modifyitems(config, items):  # noqa C901
+def pytest_collection_modifyitems(config, items):  # noqa:C901
     """Handle switching based on cli args."""
-    if config.getoption("--runsetup"):
-        # --runsetup given in cli: do not skip slow tests
+    if (
+        config.getoption("--runsetup")
+        & config.getoption("--runinteg")
+        & config.getoption("--runexpensive")
+    ):
+        # do full test suite when all flags are given
         return
-    skip_setup = pytest.mark.skip(reason="need --runsetup option to run")
-    for item in items:
-        if "setup" in item.keywords:
-            item.add_marker(skip_setup)
 
-    if config.getoption("--runinteg"):
-        return
-    skip_runinteg = pytest.mark.skip(reason="need --runinteg option to run")
-    for item in items:
-        if "runinteg" in item.keywords:
-            item.add_marker(skip_runinteg)
+    # do not add setup marks when the runsetup flag is given
+    if not config.getoption("--runsetup"):
+        skip_setup = pytest.mark.skip(reason="need --runsetup option to run")
+        for item in items:
+            if "setup" in item.keywords:
+                item.add_marker(skip_setup)
 
-    if config.getoption("--runexpensive"):
-        return
-    skip_runexpensive = pytest.mark.skip(
-        reason="need --runexpensive option to run"
-    )
-    for item in items:
-        if "runexpensive" in item.keywords:
-            item.add_marker(skip_runexpensive)
+    # do not add integ marks when the runinteg flag is given
+    if not config.getoption("--runinteg"):
+        skip_runinteg = pytest.mark.skip(
+            reason="need --runinteg option to run"
+        )
+        for item in items:
+            if "runinteg" in item.keywords:
+                item.add_marker(skip_runinteg)
+
+    # do not add expensive marks when the runexpensive flag is given
+    if not config.getoption("--runexpensive"):
+        skip_runexpensive = pytest.mark.skip(
+            reason="need --runexpensive option to run"
+        )
+        for item in items:
+            if "runexpensive" in item.keywords:
+                item.add_marker(skip_runexpensive)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
PR to correct `pytest` mark behaviour. Fixes #25 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
This PR adds a fix that allows the use of independent pytest marks. This fix now mean we can add flags to pytest calls and we can run setup, integ, and expensive tests without the previous conflict - where calling any flag erroneously triggered the entire test suite.

## Type of change
<!--- Please select from the options below --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Tested `pytest` with all possible flag combinations, see [this comment in the issue](https://github.com/datasciencecampus/transport-network-performance/issues/25#issuecomment-1719076617). Now performs as expected.

Test configuration details:
* OS: macOS
* Python version: 3.9.13
* Java version: 11
* Python management system: conda/pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->
Re-testing with all the possible `pytest` flag combinations could be beneficial to prove the fix is working on multiple machines and the GitHub action runners.

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works:
> Note: not able to add a unit test for this. 
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
None.
