### PR TITLE
Remove hard coded zoom value

### DIFF
--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -249,17 +249,15 @@ class GtfsInstance:
 
                 title_pre = "<h3 align='center' style='font-size:16px'><b>"
                 title_html = f"{title_pre}{txt}</b></h3>"
-
-                gtfs_centroid = self.feed.compute_centroid()
-                m = folium.Map(
-                    location=[gtfs_centroid.y, gtfs_centroid.x], zoom_start=5
-                )
                 geo_j = gdf.to_json()
                 geo_j = folium.GeoJson(
                     data=geo_j, style_function=lambda x: {"fillColor": "red"}
                 )
+                m = folium.Map()
                 geo_j.add_to(m)
                 m.get_root().html.add_child(folium.Element(title_html))
+                # format map zoom and center
+                m.fit_bounds(m.get_bounds())
             m.save(out_pth)
         except KeyError:
             print("Key Error. Map was not written.")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
This PR removes the need for a hard coded zoom value in `viz_stops()`. It also removes the need to compute the centroid and then use the x and y coordinates to center the folium map.

Fixes #75 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
To ensure that viz_stops() is able to adapt to different locational datasets.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring of less dynamic solution

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->  

This has been tested by running the `viz_stops()` function with and without the code to center and zoom the map. This was completed on both the tests dataset (Newport gtfs) and a GTFS dataset that is cropped around the Chester area.

Test configuration details:
* OS: Windows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: Conda


## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

