### PR TITLE
95 uc tests

### DIFF
--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -338,27 +338,58 @@ class TestDiag:
             assert uc._UrbanCentre__cluster_array[1, 5] == cluster
 
 
+# test cluster population threshold
 @pytest.mark.parametrize(
-    "cluster_pop_t, expected",
+    "cluster_pop_t, expected, clusters",
     [
-        (50000, does_not_raise()),
-        (50000.5, pytest.raises(TypeError)),
-        ("50000", pytest.raises(TypeError)),
+        (50000, does_not_raise(), [1, 0, 0]),
+        (10000, does_not_raise(), [1, 2, 0]),
+        (50000.5, pytest.raises(TypeError), []),
+        ("50000", pytest.raises(TypeError), []),
         # test value that would filter out all clusters
-        (1000000, pytest.raises(ValueError)),
+        (1000000, pytest.raises(ValueError), []),
     ],
 )
-def test_cluster_pop_t(
-    dummy_pop_array, bbox, cluster_centre, cluster_pop_t, expected
-):
-    """Test pop_threshold parameter."""
-    with expected:
-        assert (
-            ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
+class TestClusterPop:
+    """Class to test effect of diagonal boolean on output."""
+
+    def test_cluster_pop_t(
+        self,
+        dummy_pop_array,
+        bbox,
+        cluster_centre,
+        cluster_pop_t,
+        expected,
+        clusters,
+    ):
+        """Test pop_threshold parameter."""
+        with expected:
+            assert (
+                ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
+                    bbox, cluster_centre, cluster_pop_threshold=cluster_pop_t
+                )
+                is not None
+            )
+
+    def test_cluster_pop_t_output(
+        self,
+        dummy_pop_array,
+        bbox,
+        cluster_centre,
+        cluster_pop_t,
+        expected,
+        clusters,
+    ):
+        """Test pop_threshold outputs."""
+        if clusters != []:
+            uc = ucc.UrbanCentre(dummy_pop_array)
+            uc.get_urban_centre(
                 bbox, cluster_centre, cluster_pop_threshold=cluster_pop_t
             )
-            is not None
-        )
+            # checks if diagonal cell is clustered with main blob or separate
+            assert uc._UrbanCentre__urban_centres_array[0, 0] == clusters[0]
+            assert uc._UrbanCentre__urban_centres_array[0, 9] == clusters[1]
+            assert uc._UrbanCentre__urban_centres_array[6, 6] == clusters[2]
 
 
 @pytest.mark.parametrize(

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -292,12 +292,12 @@ class TestCellPop:
 
 # test diagonal boolean
 @pytest.mark.parametrize(
-    "diagonal, expected, cluster",
+    "diagonal, expected, cluster, num_clusters",
     [
-        (True, does_not_raise(), 1),
-        (False, does_not_raise(), 3),
-        (1, pytest.raises(TypeError), 0),
-        ("True", pytest.raises(TypeError), 0),
+        (True, does_not_raise(), 1, 3),
+        (False, does_not_raise(), 3, 4),
+        (1, pytest.raises(TypeError), 0, 0),
+        ("True", pytest.raises(TypeError), 0, 0),
     ],
 )
 class TestDiag:
@@ -311,6 +311,7 @@ class TestDiag:
         diagonal,
         expected,
         cluster,
+        num_clusters,
     ):
         """Test diag parameter."""
         with expected:
@@ -329,6 +330,7 @@ class TestDiag:
         diagonal,
         expected,
         cluster,
+        num_clusters,
     ):
         """Test diag parameter output."""
         if cluster != 0:
@@ -336,6 +338,7 @@ class TestDiag:
             uc.get_urban_centre(bbox, cluster_centre, diag=diagonal)
             # checks if diagonal cell is clustered with main blob or separate
             assert uc._UrbanCentre__cluster_array[1, 5] == cluster
+            assert uc._UrbanCentre__num_clusters == num_clusters
 
 
 # test cluster population threshold
@@ -392,6 +395,7 @@ class TestClusterPop:
             assert uc._UrbanCentre__urban_centres_array[6, 6] == clusters[2]
 
 
+# test adjacent cells threshold to fill
 @pytest.mark.parametrize(
     "cell_fill_t, expected, fills",
     [
@@ -448,6 +452,7 @@ class TestFill:
             assert uc._UrbanCentre__filled_array[4, 0] == fills[2]
 
 
+# test nodata parameter
 @pytest.mark.parametrize(
     "v_nodata, expected",
     [
@@ -467,6 +472,7 @@ def test_v_nodata(dummy_pop_array, bbox, cluster_centre, v_nodata, expected):
         )
 
 
+# test buffer parameter
 @pytest.mark.parametrize(
     "buffer, expected",
     [
@@ -487,6 +493,7 @@ def test_buffer(dummy_pop_array, bbox, cluster_centre, buffer, expected):
         )
 
 
+# test output types
 @pytest.mark.parametrize(
     "output, expected",
     [
@@ -511,6 +518,7 @@ def test_output_types(dummy_pop_array, bbox, cluster_centre, output, expected):
     assert type(getattr(obj, output)) == expected
 
 
+# test final output characteristics
 def test_final_output(dummy_pop_array, bbox, cluster_centre):
     """Test final output."""
     out = ucc.UrbanCentre(dummy_pop_array).get_urban_centre(

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -295,27 +295,59 @@ def test_cluster_pop_t(
 
 
 @pytest.mark.parametrize(
-    "cell_fill_t, expected",
+    "cell_fill_t, expected, fills",
     [
-        (5, does_not_raise()),
-        (5.5, pytest.raises(TypeError)),
-        ("5", pytest.raises(TypeError)),
+        (5, does_not_raise(), [1, 1, 0]),
+        (7, does_not_raise(), [1, 0, 0]),
+        (5.5, pytest.raises(TypeError), []),
+        ("5", pytest.raises(TypeError), []),
         # test values outside boundaries
-        (11, pytest.raises(ValueError)),
-        (0, pytest.raises(ValueError)),
+        (11, pytest.raises(ValueError), []),
+        (0, pytest.raises(ValueError), []),
     ],
 )
-def test_cell_fill_t(
-    dummy_pop_array, bbox, cluster_centre, cell_fill_t, expected
-):
-    """Test cell_fill_threshold parameter."""
-    with expected:
-        assert (
-            ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
+class TestFill:
+    """Class to test effect of fill threshold on output."""
+
+    def test_cell_fill_t(
+        self,
+        dummy_pop_array,
+        bbox,
+        cluster_centre,
+        cell_fill_t,
+        expected,
+        fills,
+    ):
+        """Test cell_fill_threshold parameter."""
+        with expected:
+            assert (
+                ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
+                    bbox, cluster_centre, cell_fill_treshold=cell_fill_t
+                )
+                is not None
+            )
+
+    def test_cell_fill_output(
+        self,
+        dummy_pop_array,
+        bbox,
+        cluster_centre,
+        cell_fill_t,
+        expected,
+        fills,
+    ):
+        """Test fill output."""
+        if fills != []:
+            uc = ucc.UrbanCentre(dummy_pop_array)
+            uc.get_urban_centre(
                 bbox, cluster_centre, cell_fill_treshold=cell_fill_t
             )
-            is not None
-        )
+            # fills with 5 and 7
+            assert uc._UrbanCentre__filled_array[1, 3] == fills[0]
+            # fills with 5 but not 7
+            assert uc._UrbanCentre__filled_array[1, 4] == fills[1]
+            # doesn't fill (checks if outside bounds are 0)
+            assert uc._UrbanCentre__filled_array[4, 0] == fills[2]
 
 
 @pytest.mark.parametrize(

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -493,7 +493,7 @@ def test_buffer(dummy_pop_array, bbox, cluster_centre, buffer, expected):
         )
 
 
-# test output types
+# test intermediate output types
 @pytest.mark.parametrize(
     "output, expected",
     [
@@ -518,12 +518,37 @@ def test_output_types(dummy_pop_array, bbox, cluster_centre, output, expected):
     assert type(getattr(obj, output)) == expected
 
 
-# test final output characteristics
+# test final output characteristics using defaults
 def test_final_output(dummy_pop_array, bbox, cluster_centre):
     """Test final output."""
     out = ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
         bbox, cluster_centre
     )
+
+    # uc expected coordinates
+    # coordinates will need to be recalculated if array fixture changes
+    # you can just do list(Polygon.exterior.coords) to get coordinates
+    uc_coords = [
+        (-243000.0, 6056000.0),
+        (-243000.0, 6052000.0),
+        (-240000.0, 6052000.0),
+        (-240000.0, 6053000.0),
+        (-238000.0, 6053000.0),
+        (-238000.0, 6056000.0),
+        (-243000.0, 6056000.0),
+    ]
+    assert out.loc[0][1] == Polygon(uc_coords)
+
+    # bbox expected coordinates
+    bbox_coords = [
+        (-253000.0, 6042000.0),
+        (-228000.0, 6042000.0),
+        (-228000.0, 6066000.0),
+        (-253000.0, 6066000.0),
+        (-253000.0, 6042000.0),
+    ]
+    assert out.loc[2][1] == Polygon(bbox_coords)
+
     # type of output
     assert type(out) == gpd.GeoDataFrame
 

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -29,7 +29,7 @@ def dummy_pop_array(tmp_path: str):
     dummy = np.array(
         [
             [5000, 5000, 5000, 1500, 1500, 0, 0, 0, 5000, 5000],
-            [5000, 5000, 5000, 0, 0, 0, 0, 0, 0, 0],
+            [5000, 5000, 5000, 0, 0, 1500, 0, 0, 0, 0],
             [5000, 5000, 5000, 1500, 1500, 0, 0, 0, 0, 0],
             [5000, 1500, 1500, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -234,7 +234,7 @@ def test_band_n(dummy_pop_array, bbox, cluster_centre, band, expected):
         )
 
 
-# test exceptions for cell population threshold
+# test cell population threshold
 @pytest.mark.parametrize(
     "cell_pop_t, expected, flags",
     [
@@ -290,23 +290,52 @@ class TestCellPop:
             assert uc._UrbanCentre__pop_filt_array[6, 0] == flags[2]
 
 
+# test diagonal boolean
 @pytest.mark.parametrize(
-    "diagonal, expected",
+    "diagonal, expected, cluster",
     [
-        (True, does_not_raise()),
-        (False, does_not_raise()),
-        ("True", pytest.raises(TypeError)),
+        (True, does_not_raise(), 1),
+        (False, does_not_raise(), 3),
+        (1, pytest.raises(TypeError), 0),
+        ("True", pytest.raises(TypeError), 0),
     ],
 )
-def test_diag(dummy_pop_array, bbox, cluster_centre, diagonal, expected):
-    """Test diag parameter."""
-    with expected:
-        assert (
-            ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
-                bbox, cluster_centre, diag=diagonal
+class TestDiag:
+    """Class to test effect of diagonal boolean on output."""
+
+    def test_diag(
+        self,
+        dummy_pop_array,
+        bbox,
+        cluster_centre,
+        diagonal,
+        expected,
+        cluster,
+    ):
+        """Test diag parameter."""
+        with expected:
+            assert (
+                ucc.UrbanCentre(dummy_pop_array).get_urban_centre(
+                    bbox, cluster_centre, diag=diagonal
+                )
+                is not None
             )
-            is not None
-        )
+
+    def test_diag_output(
+        self,
+        dummy_pop_array,
+        bbox,
+        cluster_centre,
+        diagonal,
+        expected,
+        cluster,
+    ):
+        """Test diag parameter output."""
+        if cluster != 0:
+            uc = ucc.UrbanCentre(dummy_pop_array)
+            uc.get_urban_centre(bbox, cluster_centre, diag=diagonal)
+            # checks if diagonal cell is clustered with main blob or separate
+            assert uc._UrbanCentre__cluster_array[1, 5] == cluster
 
 
 @pytest.mark.parametrize(

--- a/tests/urban_centres/test_urban_centres.py
+++ b/tests/urban_centres/test_urban_centres.py
@@ -1,6 +1,13 @@
 """Unit tests for transport_performance/urban_centres/urban_centres_class.
 
 TODO: add docs.
+
+Note: in the class parameterised tests below there are some arguments that are
+not used across all tests within them. This is a deliberate design choice,
+since pytest expects all parameterised arguments to be passed - removing or
+excluding from a signle test triggers errors. The alternative would be to
+separate the tests and reparameterise each separetly, but this would lead to a
+larger codebase that is more difficult to maintain.
 """
 
 import os
@@ -354,7 +361,7 @@ class TestDiag:
     ],
 )
 class TestClusterPop:
-    """Class to test effect of diagonal boolean on output."""
+    """Class to test effect of clustering pop threshold on output."""
 
     def test_cluster_pop_t(
         self,


### PR DESCRIPTION
## Description
Added unit tests to check for intermediate and final outputs of the `raster_uc` module.

Fixes #95 

## Motivation and Context
Currently tests check for input and output types, but they don't check if actual output is as expected.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Unit tests run and passed using default values. Unit tests failing as expected if modifying fixtures or expected values in assertion.

Test configuration details:
* OS: macOS Ventura 13.4.1
* Python version: 3.9.13
* Java version:
* Python management system: conda/pip

## Advice for reviewer
Where there are several tests for the same function or output, they have been grouped in classes so they use the same parametrisation. However, when output is checked, only those combinations that are expected to not return error are considered.

Note that docstrings are not included in this test script, but this will be added later.

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional comments

