### PR TITLE
135 osm filtered outputs not readable by r5py

### DIFF
--- a/notebooks/e2e/config/e2e.toml
+++ b/notebooks/e2e/config/e2e.toml
@@ -47,6 +47,7 @@ used_stops_map_path = "outputs/e2e/gtfs/used_stops_map.html"
 override = true
 input_path = "data/external/osm/wales-latest.osm.pbf"
 filtered_path = "data/processed/osm/wales_latest_filtered.osm.pbf"
+tag_filter = false
 
 [analyse_network]  # configuration for the analyse_network stage
 departure_year = 2023

--- a/notebooks/e2e/e2e.py
+++ b/notebooks/e2e/e2e.py
@@ -6,15 +6,6 @@ Am end to end example to run through urban centre detection, population
 retrieval, gtfs manipulation and validation, OSM clipping , analysing the
 transport network using `r5py` and calculating a performance metric.
 
-> Note: Some bugs have be raised as a result of developing this script. Be
-> sure to check out the follow issues on GitHub to ensure they are closed or
-> to see temporary workarounds if any of the cells herein do not run:
->
-> - [#121](
-https://github.com/datasciencecampus/transport-network-performance/issues/121)
-> for an issue with `utils/raster/sum_resample_file()` writing to new
-> directories
-
 ## Preamble
 Call in script wide imports and the configuration information.
 """

--- a/notebooks/e2e/e2e.py
+++ b/notebooks/e2e/e2e.py
@@ -287,6 +287,7 @@ if osm_config["override"]:
         pbf_pth=here(osm_config["input_path"]),
         out_pth=here(osm_config["filtered_path"]),
         bbox=osm_bbox,
+        tag_filter=osm_config["tag_filter"],
     )
 
 # %% [markdown] noqa: D212, D400, D415
@@ -302,7 +303,7 @@ urban centre destinations; in the centre, south west, and eastern regions.
 # %%
 # build the transport network
 trans_net = TransportNetwork(
-    here(osm_config["input_path"]),
+    here(osm_config["filtered_path"]),
     [here(gtfs_config["cleaned_path"])],
 )
 

--- a/notebooks/e2e/e2e.py
+++ b/notebooks/e2e/e2e.py
@@ -118,9 +118,10 @@ buffered urban centre boundary detected in the step above.
 ### Data Sources
 
 Using [GHS-POP 100m gridded](https://ghsl.jrc.ec.europa.eu/download.php?ds=pop)
-population estimaes, in a **Mollweide CRS**. The following tiles are expected
+population estimates, in a **Mollweide CRS**. The following tiles are expected
 in `config["population"]["input_dir"]`(which include the British isles and
-France):
+France). Must use 2020 Epoch or update the `subset_regex` pattern to match your
+files in the cell below:
 
 - R3-C18
 - R3-C19

--- a/notebooks/e2e/e2e.py
+++ b/notebooks/e2e/e2e.py
@@ -195,7 +195,7 @@ if gtfs_config["override"]:
     bbox_filter_gtfs(
         in_pth=here(gtfs_config["input_path"]),
         out_pth=here(gtfs_config["filtered_path"]),
-        bbox_list=gtfs_bbox,
+        bbox=gtfs_bbox,
         units=gtfs_config["units"],
         crs=uc_gdf.crs.to_string(),
     )

--- a/notebooks/e2e/e2e.py
+++ b/notebooks/e2e/e2e.py
@@ -142,6 +142,7 @@ if pop_config["override"]:
 
 # %%
 # resample 100m grids to 200m grids (default resample factor used)
+# Can take a couple of minutes...
 if pop_config["override"]:
     sum_resample_file(
         here(pop_config["merged_path"]),

--- a/notebooks/e2e/e2e.py
+++ b/notebooks/e2e/e2e.py
@@ -61,7 +61,8 @@ Merge 1Km gridded data together. Then detect the urban centre.
 Using [GHS-POP 1Km gridded](https://ghsl.jrc.ec.europa.eu/download.php?ds=pop)
 population estimaes, in a **Mollweide CRS**. The following tiles are expected
 in `config["urban_centre"]["input_dir"]`(which include the British isles and
-France):
+France). Must use 2020 Epoch or update the `subset_regex` pattern to match your
+files in the cell below:
 
 - R3-C18
 - R3-C19

--- a/src/transport_performance/osm/osm_utils.py
+++ b/src/transport_performance/osm/osm_utils.py
@@ -83,6 +83,9 @@ def filter_osm(
         f"bottom={bbox[1]}",
         f"right={bbox[2]}",
         f"top={bbox[3]}",
+        # https://github.com/conveyal/r5/issues/276#issuecomment-306638448
+        "completeWays=yes",
+        "completeRelations=yes",
     ]
     if tag_filter:  # optionaly filter ways
         print("Rejecting ways:  waterway, landuse & natural.")

--- a/src/transport_performance/osm/osm_utils.py
+++ b/src/transport_performance/osm/osm_utils.py
@@ -30,8 +30,8 @@ def filter_osm(
         Bounding box used to perform the filter, in left, bottom, right top
         order. Defaults to [-3.01, 51.58, -2.99, 51.59].
     tag_filter: (bool, optional)
-        Should non-highway ways be filtered? Excludes waterway, landuse &
-        natural. Defaults to True.
+        Should non-highway ways be filtered? Excludes buildings, waterway,
+        landuse & natural. Defaults to True.
     install_osmosis: (bool, optional)
         Should brew be used to install osmosis if not found. Defaults to False.
 

--- a/src/transport_performance/osm/osm_utils.py
+++ b/src/transport_performance/osm/osm_utils.py
@@ -88,8 +88,15 @@ def filter_osm(
         "completeRelations=yes",
     ]
     if tag_filter:  # optionaly filter ways
-        print("Rejecting ways:  waterway, landuse & natural.")
-        cmd.extend(["--tf", "reject-ways", "waterway=* landuse=* natural=*"])
+        print("Rejecting ways: buildings, waterway, landuse & natural.")
+        cmd.extend(
+            [
+                "--tf",
+                "reject-ways",
+                "building=*",
+                "waterway=* landuse=* natural=*",
+            ]
+        )
 
     cmd.extend(["--used-node", "--write-pbf", out_pth])
 

--- a/src/transport_performance/osm/osm_utils.py
+++ b/src/transport_performance/osm/osm_utils.py
@@ -94,7 +94,9 @@ def filter_osm(
                 "--tf",
                 "reject-ways",
                 "building=*",
-                "waterway=* landuse=* natural=*",
+                "waterway=*",
+                "landuse=*",
+                "natural=*",
             ]
         )
 

--- a/tests/osm/test_osm_utils.py
+++ b/tests/osm/test_osm_utils.py
@@ -84,7 +84,7 @@ class TestFilterOsm(object):
         # collect print statements
         func_out = mock_print.mock_calls
         assert func_out == [
-            call("Rejecting ways:  waterway, landuse & natural.")
+            call("Rejecting ways: buildings, waterway, landuse & natural.")
         ], f"Expected print statement not encountered. Got: {func_out}"
 
     @pytest.mark.runinteg


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Fixes #135 
Filtering with bbox specified in e2e.py works with `r5py.TransportNetwork`.

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
I noticed this behaviour was very specific to the bounding box passed to `filter_osm` in the e2e.py. 

Example failure:

```
filter_osm(
    osm_pth,
    out_pth=here("foobar.osm.pbf"),
    bbox=[-3.203, 51.435, -2.747, 51.735])

filtered_net = r5py.TransportNetwork(filtered_osm_pth)

>>> ...
>>> java.lang.java.lang.NullPointerException: java.lang.NullPointerException
```

Nudging the xmin value slightly Eastwards resulted in a pass, eg this worked: `bbox=[-3.200, 51.435879751420764, -2.747777821171413, 51.735628827738644]`

The required patch was quoted [here](https://github.com/conveyal/r5/issues/276#issuecomment-306638448).

The problem seems to be when you happen to filter a way or relation that is referenced in a turn restriction within the bounding box. [Osmosis](https://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage_0.48) to the rescue - it has parameters to help with this. Namely:

> | completeWays | Include all available nodes for ways which have at least one node in the bounding box. Supersedes cascadingRelations. |

> | completeRelations | Include all available relations which are members of relations which have at least one member in the bounding box. Implies completeWays. Supersedes cascadingRelations. |

Finally, on inspection of studious sniffle, I could see that the tag filter also removed all buildings, where our approach was not. I cannot recall a reason not to do that so have implemented it here. I've refactored a print statement and unit test to account for that.

## Type of change
<!--- Please select from the options below --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Have rerun test seuite with --runinteg option, suite passes.

Test configuration details:
* OS: macos
* Python version: Python 3.9.13
* Java version: openjdk 11.0.19 2023-04-18 LTS
* Python management system: pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - could be worth doing, though definitely a --runexpensive test.
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
