### PR TITLE
57 rasterpop coverage

### DIFF
--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -4,9 +4,6 @@ Fixtures used in this file geographically represent a small area over ONS site
 in Newport. The data vales do not represent any real or meaningfull measurments
 , they are purely for use as a unit test and mimic input data used in this repo
 .
-
-Note: this suite of tests does not cover plotting methods. TODO add plotting
-unit tests. See issue #43.
 """
 
 import os

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -624,3 +624,33 @@ class TestRasterPop:
         rp.get_pop(xarr_1_aoi[0])
         with does_not_raise():
             rp.plot(which="folium")
+
+    def test_plot_cartopy_unknown_attr_location(
+        self,
+        xarr_1_fpath: str,
+        xarr_1_aoi: tuple,
+    ) -> None:
+        """Test cartopy plotting backend with an unknown attribute location.
+
+        Parameters
+        ----------
+        xarr_1_fpath : str
+            Filepath to dummy data.
+        xarr_1_aoi : tuple
+            Area of interest for dummy data.
+
+        """
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0])
+        test_attr_location = "unknown"
+        with pytest.raises(
+            ValueError,
+            match=(
+                f"Unrecognised value for `attr_location` {test_attr_location}."
+                "Expecting one of "
+            ),
+        ):
+            rp.plot(
+                which="cartopy",
+                attr_location=test_attr_location,
+            )

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -21,6 +21,7 @@ from shapely.geometry import Polygon, Point
 from numpy.dtypes import Float64DType
 from pytest_lazyfixture import lazy_fixture
 from _pytest.python_api import RaisesContext
+from contextlib import nullcontext as does_not_raise
 
 from transport_performance.population.rasterpop import RasterPop
 from transport_performance.utils.test_utils import _np_to_rioxarray
@@ -601,3 +602,25 @@ class TestRasterPop:
             ),
         ):
             rp.plot(which=unknown_plot_backend)
+
+    def test_plot_foliumn_no_uc(
+        self,
+        xarr_1_fpath: str,
+        xarr_1_aoi: tuple,
+    ) -> None:
+        """Test folium plotting backend with no urban centre.
+
+        Unit test written to capture fix for issue 52.
+
+        Parameters
+        ----------
+        xarr_1_fpath : str
+            file path to dummy data.
+        xarr_1_aoi : tuple
+            area of interest polygon for dummy data.
+
+        """
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0])
+        with does_not_raise():
+            rp.plot(which="folium")

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -508,3 +508,50 @@ class TestRasterPop:
         assert np.array_equal(
             pop_gdf.within_urban_centre, xarr_1_uc[1]["within_uc"]
         )
+
+    @pytest.mark.parametrize(
+        "which, save_folder, save_filename",
+        [
+            ("folium", "outputs", "folium.html"),
+            ("cartopy", "outputs", "cartopy.png"),
+            ("matplotlib", "outputs", "matplotlib.png"),
+        ],
+    )
+    def test_plot_on_pass(
+        self,
+        xarr_1_fpath: str,
+        xarr_1_aoi: tuple,
+        xarr_1_uc: tuple,
+        tmp_path: str,
+        which: str,
+        save_folder: str,
+        save_filename: str,
+    ) -> None:
+        """Test plotting methods.
+
+        Parameters
+        ----------
+        xarr_1_fpath : str
+            filepath to dummy raster data
+        xarr_1_aoi : tuple
+            aoi polygon for dummy input
+        xarr_1_uc : tuple
+            urban centre polugon for dummy input
+        tmp_path : str
+            temporary path to save output within
+        which : str
+            plotting backend to use
+        save_folder: str
+            folder to save output within
+        save_filename : str
+            filename to use when saving the file within the temp directory
+
+        """
+        # create the full output path
+        output_path = os.path.join(tmp_path, save_folder, save_filename)
+
+        # run raster pop and assert that the file is generated
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
+        rp.plot(which=which, save=output_path)
+        assert os.path.exists(output_path)

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -555,3 +555,19 @@ class TestRasterPop:
         rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
         rp.plot(which=which, save=output_path)
         assert os.path.exists(output_path)
+
+    def test_plot_before_get_data(self, xarr_1_fpath: str):
+        """Test case where plot is called before getting data.
+
+        Parameters
+        ----------
+        xarr_1_fpath : str
+            file path to dummy data
+
+        """
+        rp = RasterPop(xarr_1_fpath)
+        with pytest.raises(
+            NotImplementedError,
+            match="Unable to call `plot` without calling `get_pop`.",
+        ):
+            rp.plot()

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -556,13 +556,13 @@ class TestRasterPop:
         rp.plot(which=which, save=output_path)
         assert os.path.exists(output_path)
 
-    def test_plot_before_get_data(self, xarr_1_fpath: str):
+    def test_plot_before_get_data(self, xarr_1_fpath: str) -> None:
         """Test case where plot is called before getting data.
 
         Parameters
         ----------
         xarr_1_fpath : str
-            file path to dummy data
+            file path to dummy data.
 
         """
         rp = RasterPop(xarr_1_fpath)
@@ -571,3 +571,33 @@ class TestRasterPop:
             match="Unable to call `plot` without calling `get_pop`.",
         ):
             rp.plot()
+
+    def test_plot_unknown_which(
+        self,
+        xarr_1_fpath: str,
+        xarr_1_aoi: tuple,
+        xarr_1_uc: tuple,
+    ) -> None:
+        """Test a plot call with an unknown backend plot type.
+
+        Parameters
+        ----------
+        xarr_1_fpath : str
+            file path to dummy data.
+        xarr_1_aoi : tuple
+            area of interest polygon for dummy data.
+        xarr_1_uc : tuple
+            urban centre polygon for dummy data.
+
+        """
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
+        unknown_plot_backend = "unknown"
+        with pytest.raises(
+            ValueError,
+            match=(
+                f"Unrecognised value for `which` {unknown_plot_backend}. "
+                "Must be one of "
+            ),
+        ):
+            rp.plot(which=unknown_plot_backend)

--- a/tests/population/test_vectorpop.py
+++ b/tests/population/test_vectorpop.py
@@ -1,0 +1,23 @@
+"""Unit tests for transport_performance/population/vectorpop.py.
+
+At this stage, VectorPop has not been implemented, so the extent of this test
+suite is to ensure the NotImplementedError is raised.
+
+TODO: add unit test for methods once VectorPop has been implemented.
+"""
+
+import pytest
+
+from transport_performance.population.vectorpop import VectorPop
+
+
+class TestVectorPop:
+    """A class to test VectorPop methods."""
+
+    def test_vectorpop_not_implemented(self) -> None:
+        """Test VectorPop raises a not implemented error."""
+        with pytest.raises(
+            NotImplementedError,
+            match="This class has not yet been implemented",
+        ):
+            VectorPop()


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Improve coverage of `rasterpop` unit tests. Closes #43, #57. 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
Add unit test for `rasterpop` plotting functions, to improve the coverage of this module. Also adds a simple, 'Not Implemented' unit test for `vectorpop` to cover off this placeholder module.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

This PR only add new unit tests. All unit tests (previous and new) run and raise no new warnings. This PR adds in new unit tests such that:
- `rasterpop` coverage 53% -> 100%
- `vectorpop` coverage 0% -> 100% (mainly to ensure the not implemented error is raised)

Test configuration details:
* OS: macOS
* Python version: 3.9.13
* Java version: 11
* Python management system: conda/pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->
Will improve on this test suite when working on #54 - will be generalising the module to use `defence.py` at which point unit tests on the inputs can be added.

Would also like to get your opinion on whether the `--runexpensive` flag maybe useful for these plot tests?

Future `rasterpop` issues/PRs have a dependency on this PR, so I'll continue `rasterpop` dev work once we have merged this PR.

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
None
