### PR TITLE
80 default out pth argument in transport performanceosmosm utilspy

### DIFF
--- a/src/transport_performance/osm/osm_utils.py
+++ b/src/transport_performance/osm/osm_utils.py
@@ -1,6 +1,8 @@
 """Utility functions for OSM files."""
 import subprocess
 from pyprojroot import here
+from typing import Union
+import pathlib
 
 from transport_performance.utils.defence import (
     _type_defence,
@@ -11,12 +13,16 @@ from transport_performance.utils.defence import (
 
 
 def filter_osm(
-    pbf_pth=here("tests/data/newport-2023-06-13.osm.pbf"),
-    out_pth="filtered.osm.pbf",
-    bbox=[-3.01, 51.58, -2.99, 51.59],
-    tag_filter=True,
-    install_osmosis=False,
-):
+    pbf_pth: Union[str, pathlib.PosixPath] = here(
+        "tests/data/newport-2023-06-13.osm.pbf"
+    ),
+    out_pth: Union[str, pathlib.PosixPath] = here(
+        "outputs/osm/filtered.osm.pbf"
+    ),
+    bbox: list = [-3.01, 51.58, -2.99, 51.59],
+    tag_filter: bool = True,
+    install_osmosis: bool = False,
+) -> None:
     """Filter an osm.pbf file to a bbox. Relies on homebrew with osmosis.
 
     Parameters
@@ -25,7 +31,7 @@ def filter_osm(
         Path to the open street map pbf to be filtered. Defaults to
         here("tests/data/newport-2023-06-13.osm.pbf").
     out_pth: ((str, pathlib.PosixPath), optional)
-        Path to write to. Defaults to "filtered.osm.pbf".
+        Path to write to. Defaults to here("outputs/osm/filtered.osm.pbf").
     bbox:  (list, optional)
         Bounding box used to perform the filter, in left, bottom, right top
         order. Defaults to [-3.01, 51.58, -2.99, 51.59].

--- a/tests/osm/test_osm_utils.py
+++ b/tests/osm/test_osm_utils.py
@@ -61,7 +61,9 @@ class TestFilterOsm(object):
             filter_osm(bbox=[0, 1.1, 0.1, 1.2])
 
     @patch("builtins.print")
-    def test_filter_osm_defense_missing_osmosis(self, mock_print, mocker):
+    def test_filter_osm_defense_missing_osmosis(
+        self, mock_print, mocker, tmpdir
+    ):
         """Assert func behaves when osmosis is missing and install=False."""
         with pytest.raises(
             Exception, match="`osmosis` is not found. Please install."
@@ -71,7 +73,7 @@ class TestFilterOsm(object):
                 "transport_performance.osm.osm_utils.subprocess.run",
                 side_effect=FileNotFoundError("No osmosis here..."),
             )
-            filter_osm()
+            filter_osm(out_pth=os.path.join(tmpdir, "test-filter-osm.osm.pbf"))
         assert (
             mock_missing_osmosis.called
         ), "`mock_missing_osmosis` was not called."
@@ -83,9 +85,10 @@ class TestFilterOsm(object):
         ), f"Expected command got by mocker changed. Got: {subprocess_cmd} "
         # collect print statements
         func_out = mock_print.mock_calls
+        exp = "Rejecting ways:  waterway, landuse & natural."
         assert func_out == [
-            call("Rejecting ways:  waterway, landuse & natural.")
-        ], f"Expected print statement not encountered. Got: {func_out}"
+            call(exp)
+        ], f"Expected print statement {exp} not found. Got: {func_out}"
 
     @pytest.mark.runinteg
     @patch("builtins.print")


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->

Fixes #80 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
* Default path now writes to `outputs/osm`
* Refactored test suite to account for this change.
* Type setting in function signature
## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: macos
* Python version: 3.9.13
* Java version: openjdk 11.0.19 2023-04-18 LTS
* Python management system: pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
