### PR TITLE
53 54 56 population defence

### DIFF
--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -20,6 +20,7 @@ from transport_performance.utils.defence import (
     _is_expected_filetype,
     _type_defence,
     _handle_path_like,
+    _check_parent_dir_exists,
 )
 
 
@@ -503,9 +504,7 @@ class RasterPop:
 
         # write to file if filepath is given
         if save is not None:
-            out_df = os.path.dirname(save)
-            if not os.path.exists(out_df):
-                os.mkdir(out_df)
+            _check_parent_dir_exists(save, "save", create=True)
             m.save(save)
             m = None
 
@@ -676,9 +675,7 @@ class RasterPop:
         # write to file if filepath is given, since there is no figure, need to
         # get the current figure and resize it to match the axis before saving
         if save is not None:
-            out_df = os.path.dirname(save)
-            if not os.path.exists(out_df):
-                os.mkdir(out_df)
+            _check_parent_dir_exists(save, "save", create=True)
             fig = plt.gcf()
             fig.set_size_inches(*figsize)
             fig.savefig(save)
@@ -717,9 +714,7 @@ class RasterPop:
 
         # write to file if filepath is given
         if save is not None:
-            out_df = os.path.dirname(save)
-            if not os.path.exists(out_df):
-                os.mkdir(out_df)
+            _check_parent_dir_exists(save, "save", create=True)
             fig.savefig(save)
             ax = None
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -189,8 +189,9 @@ class RasterPop:
         - Cartopy backend: `help(RasterPop._plot_cartopy)`
 
         """
-        # input type defence
+        # input type defence - setting which to lower case to improve usability
         _type_defence(which, "which", str)
+        which = which.lower()
         if save is not None:
             save = _handle_path_like(save, "save")
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -727,6 +727,9 @@ class RasterPop:
             writing to file, None is return.
 
         """
+        # handle kwarg type checks
+        _type_defence(figsize, "figsize", tuple)
+
         # handle matplotlib and rioxarry steps
         fig, ax = plt.subplots(figsize=figsize)
         self._xds.plot(ax=ax)

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -125,6 +125,7 @@ class RasterPop:
         self._read_and_clip(aoi_bounds, aoi_crs, var_name)
 
         # round population estimates, if requested
+        _type_defence(round, "round", bool)
         if round:
             self._round_population()
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -326,12 +326,9 @@ class RasterPop:
             When `urban_centre_bounds` is not a shapely Polygon.
 
         """
-        # defend against case where urban_centre_bounds is not a polygon
-        if not isinstance(urban_centre_bounds, Polygon):
-            raise TypeError(
-                f"Expected type {Polygon.__name__} for `urban_centre_bounds`, "
-                f"got {type(urban_centre_bounds).__name__}."
-            )
+        # input type defences
+        _type_defence(urban_centre_bounds, "urban_centre_bounds", Polygon)
+        _type_defence(urban_centre_crs, "urban_centre_crs", (str, type(None)))
 
         # match the crs if is one isn't provided - default assumption if this
         # arg is not set, and a CRS is needed when building the gdf below

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -16,6 +16,9 @@ from typing import Union, Type, Tuple
 from shapely.geometry.polygon import Polygon
 from matplotlib import colormaps
 from cartopy.mpl.geoaxes import GeoAxes
+from transport_performance.utils.defence import (
+    _is_expected_filetype,
+)
 
 
 class RasterPop:
@@ -56,8 +59,7 @@ class RasterPop:
     def __init__(self, filepath: Union[str, bytes, os.PathLike]) -> None:
 
         # defend against cases where input is not a file and does not exist
-        if not os.path.isfile(filepath):
-            raise FileNotFoundError(f"{filepath} is not a file.")
+        _is_expected_filetype(filepath, "filepath", exp_ext=".tif")
 
         self.__filepath = filepath
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -19,6 +19,7 @@ from cartopy.mpl.geoaxes import GeoAxes
 from transport_performance.utils.defence import (
     _is_expected_filetype,
     _type_defence,
+    _handle_path_like,
 )
 
 
@@ -187,6 +188,11 @@ class RasterPop:
         - Cartopy backend: `help(RasterPop._plot_cartopy)`
 
         """
+        # input type defence
+        _type_defence(which, "which", str)
+        if save is not None:
+            save = _handle_path_like(save, "save")
+
         # record of valid which values
         WHICH_VALUES = {"matplotlib", "catropy", "folium"}
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -407,7 +407,7 @@ class RasterPop:
         boundary_color : str, optional
             Color of the boundary lines, by default "red". Could also be a
             hexstring.
-        boundary_weight : float, optional
+        boundary_weight : int, optional
             Weight (in pixels) of the boudary lines, by default 2.
 
         Returns
@@ -429,6 +429,13 @@ class RasterPop:
         .. [3] https://matplotlib.org/stable/tutorials/colors/colormaps.html
 
         """
+        # kwarg type checks
+        _type_defence(tiles, "tiles", str)
+        _type_defence(attr, "attr", str)
+        _type_defence(cmap, "cmap", str)
+        _type_defence(boundary_color, "boundary_color", str)
+        _type_defence(boundary_weight, "boundary_weight", int)
+
         # add a base map with no tile - then is it not on a layer control
         m = folium.Map(tiles=None, control_scale=True, zoom_control=True)
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -168,7 +168,7 @@ class RasterPop:
         Union[folium.Map, Type[GeoAxes], plt.Axes, None]
             A folium map is returned when the `folium` backend is used. A
             matplotlib Axes object is returned when the `matplotlib` backend is
-            used. A matplotlib/cartopy GeoAxes object is return when the
+            used. A matplotlib/cartopy GeoAxes object is returned when the
             `cartopy` backend is used. None will be returned when saving to
             file.
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -586,6 +586,18 @@ class RasterPop:
         .. [2] https://matplotlib.org/stable/tutorials/colors/colormaps.html
 
         """
+        # kwarg type checks
+        _type_defence(figsize, "figsize", tuple)
+        _type_defence(map_tile_zoom, "map_tile_zoom", int)
+        _type_defence(cmap, "cmap", str)
+        _type_defence(cbar_fraction, "cbar_fraction", float)
+        _type_defence(cbar_pad, "cbar_pad", float)
+        _type_defence(cbar_label, "cbar_label", str)
+        _type_defence(var_attr, "var_attr", str)
+        _type_defence(base_map_attr, "base_map_attr", str)
+        _type_defence(attr_font_size, "attr_font_size", float)
+        _type_defence(attr_location, "attr_location", str)
+
         # make attribution location dictionary
         ATTR_LOC = {
             "bottom_left": {

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -77,7 +77,7 @@ class RasterPop:
         aoi_bounds: Type[Polygon],
         aoi_crs: str = None,
         round: bool = False,
-        threshold: int = None,
+        threshold: Union[int, float] = None,
         var_name: str = "population",
         urban_centre_bounds: Type[Polygon] = None,
         urban_centre_crs: str = None,
@@ -96,7 +96,7 @@ class RasterPop:
             data.
         round : bool, optional
             Round population estimates to the nearest whole integer.
-        threshold : int, optional
+        threshold : Union[int, float], optional
             Threshold population estimates, where values below the set
             threshold will be set to nan, by default None which means no
             thresholding will occur.
@@ -262,10 +262,11 @@ class RasterPop:
         """Round population data."""
         self._xds = np.rint(self._xds)
 
-    def _threshold_population(self, threshold: int) -> None:
+    def _threshold_population(self, threshold: Union[int, float]) -> None:
         """Threshold population data."""
         # `where()` is working differently to expectation here - it keeps
         # values above the threshold and otherwise sets them to nan.
+        _type_defence(threshold, "threshold", (int, float))
         self._xds = self._xds.where(self._xds >= threshold)
 
     def _to_geopandas(self, round: bool = False) -> None:

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -18,6 +18,7 @@ from matplotlib import colormaps
 from cartopy.mpl.geoaxes import GeoAxes
 from transport_performance.utils.defence import (
     _is_expected_filetype,
+    _type_defence,
 )
 
 
@@ -232,12 +233,10 @@ class RasterPop:
             The variable name, by default "population".
 
         """
-        # defend against case where aoi_bounds is not a shapely polygon
-        if not isinstance(aoi_bounds, Polygon):
-            raise TypeError(
-                f"Expected type {Polygon.__name__} for `aoi_bounds`, "
-                f"got {type(aoi_bounds).__name__}."
-            )
+        # input type defence checks
+        _type_defence(aoi_bounds, "aoi_bounds", Polygon)
+        _type_defence(aoi_crs, "aoi_crs", (str, type(None)))
+        _type_defence(var_name, "var_name", str)
 
         # convert aoi bounds CRS if needed
         if aoi_crs is not None:

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -1165,3 +1165,34 @@ class TestRasterPop:
                 attr_font_size=attr_font_size,
                 attr_location=attr_location,
             )
+
+    @pytest.mark.parametrize(
+        "figsize, expected",
+        [
+            # test figsize incorrect type
+            (
+                1.0,
+                pytest.raises(
+                    TypeError,
+                    match="^`figsize` expected .*tuple.*. Got .*float.*",
+                ),
+            ),
+        ],
+    )
+    def test_plot_matplotlib_type_defence(
+        self,
+        xarr_1_fpath,
+        xarr_1_aoi,
+        xarr_1_uc,
+        figsize,
+        expected: Type[RaisesContext],
+    ) -> None:
+        """Unit test _plot_folium kwargs type raises."""
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
+        with expected:
+            rp.plot(
+                which="matplotlib",
+                save=None,
+                figsize=figsize,
+            )

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -459,7 +459,7 @@ class TestRasterPop:
 
     @pytest.mark.parametrize(
         "aoi_bounds, aoi_crs, round, threshold, var_name, urban_centre_bounds,"
-        " , urban_centre_crs, expected",
+        " urban_centre_crs, expected",
         [
             # test aoi_bounds incorrect type
             (

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -417,7 +417,7 @@ class TestRasterPop:
             (
                 "test.tif",
                 pytest.raises(
-                    FileExistsError, match="test.tif not found on file."
+                    FileNotFoundError, match="test.tif not found on file."
                 ),
             ),
             # existing file but an incorrect file type

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -680,6 +680,7 @@ class TestRasterPop:
             ("folium", "outputs", "folium.html"),
             ("cartopy", "outputs", "cartopy.png"),
             ("matplotlib", "outputs", "matplotlib.png"),
+            ("MaTpLoTlIb", "outputs", "matplotlib.png"),  # test .lower()
         ],
     )
     def test_plot_on_pass(

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -413,7 +413,14 @@ class TestRasterPop:
     @pytest.mark.parametrize(
         "fpath, aoi_bounds, urban_centre_bounds, expected",
         [
-            ("test.tif", None, None, pytest.raises(FileNotFoundError)),
+            (
+                "test.tif",
+                None,
+                None,
+                pytest.raises(
+                    FileExistsError, match="test.tif not found on file."
+                ),
+            ),
             (
                 lazy_fixture("xarr_1_fpath"),
                 ("test"),

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -811,6 +811,24 @@ class TestRasterPop:
         with expected:
             rp.plot(which=which, save=save)
 
+    def test_plot_unknown_kwarg(
+        self,
+        xarr_1_fpath,
+        xarr_1_aoi,
+        xarr_1_uc,
+    ) -> None:
+        """Unit test unknown kwarg in plot."""
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"_plot_folium\(\) got an unexpected keyword argument "
+                r"'unknown_kwarg'"
+            ),
+        ):
+            rp.plot(unknown_kwarg=None)
+
     @pytest.mark.parametrize(
         "tiles, attr, cmap, boundary_color, boundary_weight, expected",
         [

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -811,6 +811,97 @@ class TestRasterPop:
         with expected:
             rp.plot(which=which, save=save)
 
+    @pytest.mark.parametrize(
+        "tiles, attr, cmap, boundary_color, boundary_weight, expected",
+        [
+            # test tiles incorrect type
+            (
+                1.0,
+                "",
+                "",
+                "",
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`tiles` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test attr incorrect type
+            (
+                "",
+                1.0,
+                "",
+                "",
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`attr` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test cmap incorrect type
+            (
+                "",
+                "",
+                1.0,
+                "",
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`cmap` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test boundary_color incorrect type
+            (
+                "",
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`boundary_color` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test boundary_weight incorrect type
+            (
+                "",
+                "",
+                "",
+                "",
+                1.0,
+                pytest.raises(
+                    TypeError,
+                    match="^`boundary_weight` expected .*int.*. Got .*float.*",
+                ),
+            ),
+        ],
+    )
+    def test_plot_folium_type_defence(
+        self,
+        xarr_1_fpath,
+        xarr_1_aoi,
+        xarr_1_uc,
+        tiles,
+        attr,
+        cmap,
+        boundary_color,
+        boundary_weight,
+        expected: Type[RaisesContext],
+    ) -> None:
+        """Unit test _plot_folium kwargs type raises."""
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
+        with expected:
+            rp.plot(
+                which="folium",
+                save=None,
+                tiles=tiles,
+                attr=attr,
+                cmap=cmap,
+                boundary_color=boundary_color,
+                boundary_weight=boundary_weight,
+            )
+
     def test_plot_foliumn_no_uc(
         self,
         xarr_1_fpath: str,

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -411,35 +411,30 @@ class TestRasterPop:
         assert np.array_equal(pop_gdf[var_name], expected[1][key])
 
     @pytest.mark.parametrize(
-        "fpath, aoi_bounds, urban_centre_bounds, expected",
+        "fpath, expected",
         [
+            # non-existant file
             (
                 "test.tif",
-                None,
-                None,
                 pytest.raises(
                     FileExistsError, match="test.tif not found on file."
                 ),
             ),
+            # existing file but an incorrect file type
             (
-                lazy_fixture("xarr_1_fpath"),
-                ("test"),
-                None,
-                pytest.raises(TypeError),
-            ),
-            (
-                lazy_fixture("xarr_1_fpath"),
-                lazy_fixture("xarr_1_aoi"),
-                "test",
-                pytest.raises(TypeError),
+                "tests/data/newport-2023-06-13.osm.pbf",
+                pytest.raises(
+                    ValueError,
+                    match=(
+                        "`filepath` expected file extension .tif. Found .pbf",
+                    ),
+                ),
             ),
         ],
     )
-    def test_rasterpop_raises(
+    def test_rasterpop_init_raises(
         self,
         fpath: str,
-        aoi_bounds: Tuple[str],
-        urban_centre_bounds: str,
         expected: Type[RaisesContext],
     ) -> None:
         """Test raises statements in RasterPop.
@@ -447,12 +442,7 @@ class TestRasterPop:
         Parameters
         ----------
         fpath : str
-            Filepath to dummy data.
-        aoi_bounds : Tuple[str]
-            Area of interest bounds, as a tuple where the 0th index is used (
-            for consistency with the `xarr1_aoi` fixture).
-        urban_centre_bounds : str
-            Urban centre bounds test string.
+            Filepath to non-existant/incorrect file type data.
         expected : Type[RaisesContext]
             Expected raise result.
 
@@ -465,10 +455,180 @@ class TestRasterPop:
         """
         # trigger the raise and ensure it matches the expected type.
         with expected:
-            rp = RasterPop(fpath)
+            RasterPop(fpath)
+
+    @pytest.mark.parametrize(
+        "aoi_bounds, aoi_crs, round, threshold, var_name, urban_centre_bounds,"
+        " , urban_centre_crs, expected",
+        [
+            # test aoi_bounds incorrect type
+            (
+                "test",
+                None,
+                False,
+                None,
+                "population",
+                lazy_fixture("xarr_1_uc"),
+                None,
+                pytest.raises(
+                    TypeError,
+                    match="^`aoi_bounds` expected .*Polygon.*. Got .*str.*",
+                ),
+            ),
+            # test aoi_crs incorrect type
+            (
+                lazy_fixture("xarr_1_aoi"),
+                1.0,
+                False,
+                None,
+                "population",
+                lazy_fixture("xarr_1_uc"),
+                None,
+                pytest.raises(
+                    TypeError,
+                    match="^`aoi_crs` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test bounds incorrect type
+            (
+                lazy_fixture("xarr_1_aoi"),
+                None,
+                "test",
+                None,
+                "population",
+                lazy_fixture("xarr_1_uc"),
+                None,
+                pytest.raises(
+                    TypeError,
+                    match="^`round` expected .*bool.*. Got .*str.*",
+                ),
+            ),
+            # test threshold incorrect type
+            (
+                lazy_fixture("xarr_1_aoi"),
+                None,
+                False,
+                "test",
+                "population",
+                lazy_fixture("xarr_1_uc"),
+                None,
+                pytest.raises(
+                    TypeError,
+                    match=(
+                        "^`threshold` expected (.*int.*float.*)."
+                        " Got .*str.*"
+                    ),
+                ),
+            ),
+            # test var_name incorrect type
+            (
+                lazy_fixture("xarr_1_aoi"),
+                None,
+                False,
+                None,
+                1.0,
+                lazy_fixture("xarr_1_uc"),
+                None,
+                pytest.raises(
+                    TypeError,
+                    match="^`var_name` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test urban_centre_bounds incorrect type
+            (
+                lazy_fixture("xarr_1_aoi"),
+                None,
+                False,
+                None,
+                "population",
+                "test",
+                None,
+                pytest.raises(
+                    TypeError,
+                    match=(
+                        "^`urban_centre_bounds` expected .*Polygon.*."
+                        " Got .*str.*"
+                    ),
+                ),
+            ),
+            # test urban_centre_crs incorrect type
+            (
+                lazy_fixture("xarr_1_aoi"),
+                None,
+                False,
+                None,
+                "population",
+                lazy_fixture("xarr_1_uc"),
+                1.0,
+                pytest.raises(
+                    TypeError,
+                    match=(
+                        "^`urban_centre_crs` expected .*str.*. Got .*float.*"
+                    ),
+                ),
+            ),
+        ],
+    )
+    def test_rasterpop_get_pop_raises(
+        self,
+        xarr_1_fpath: str,
+        aoi_bounds: tuple,
+        aoi_crs,
+        round,
+        threshold,
+        var_name,
+        urban_centre_bounds: tuple,
+        urban_centre_crs,
+        expected: Type[RaisesContext],
+    ) -> None:
+        """Test raises statements in RasterPop `get_population()` method.
+
+        Parameters
+        ----------
+        xarr_1_fpath : str
+            Filepath to dummy data.
+        aoi_bounds : tuple
+            Area of interest bounds, as a tuple where the 0th index is used (
+            for consistency with the `xarr_1_aoi` fixture).
+        aoi_crs
+            see `get_data()` docstring
+        round
+            see `get_data()` docstring
+        threshold
+            see `get_data()` docstring
+        var_name
+            see `get_data()` docstring
+        urban_centre_bounds : tuple
+            Urban centre bounds test, as a tuple where the 0th index is used (
+            for consistency with the `xarr_1_uc` fixture).
+        urban_centre_crs
+            see `get_data()` docstring
+        expected : Type[RaisesContext]
+            Expected raise result.
+
+        Note
+        ----
+        1. For more information on the other parameters used in this test see
+        the `get_pop` docstring. Avoiding duplication by not describing or
+        type hinting them here.
+        2. When testing `aoi_bounds` and `urban_centre_bounds` input types,
+        the capabilty to index strings is being somewhat 'abused' here such
+        that "t" out of "test" is being used as the test argument. This
+        presents no technical issues because passing "t" is equally valid as
+        "test" in this case.
+
+        """
+        # trigger the raise and ensure it matches the expected type.
+        with expected:
+            rp = RasterPop(xarr_1_fpath)
             rp.get_pop(
                 aoi_bounds=aoi_bounds[0],
-                urban_centre_bounds=urban_centre_bounds,
+                aoi_crs=aoi_crs,
+                round=round,
+                threshold=threshold,
+                var_name=var_name,
+                urban_centre_bounds=urban_centre_bounds[0],
+                urban_centre_crs=urban_centre_crs,
             )
 
     def test_rasterpop_crs_conversion(

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -426,7 +426,7 @@ class TestRasterPop:
                 pytest.raises(
                     ValueError,
                     match=(
-                        "`filepath` expected file extension .tif. Found .pbf",
+                        "`filepath` expected file extension .tif. Found .pbf"
                     ),
                 ),
             ),

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -737,11 +737,49 @@ class TestRasterPop:
         ):
             rp.plot()
 
+    @pytest.mark.parametrize(
+        "which, save, expected",
+        [
+            # test an unknown which argument incorrect type
+            (
+                "unknown",
+                None,
+                pytest.raises(
+                    ValueError,
+                    match=(
+                        "Unrecognised value for `which` unknown. "
+                        "Must be one of "
+                    ),
+                ),
+            ),
+            # test which argument incorrect type
+            (
+                1.0,
+                None,
+                pytest.raises(
+                    TypeError,
+                    match="^`which` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test save argument incorrect type
+            (
+                "folium",
+                1.0,
+                pytest.raises(
+                    TypeError,
+                    match="^`save` expected .*path-like.*, found .*float.*",
+                ),
+            ),
+        ],
+    )
     def test_plot_unknown_which(
         self,
         xarr_1_fpath: str,
         xarr_1_aoi: tuple,
         xarr_1_uc: tuple,
+        which,
+        save,
+        expected: Type[RaisesContext],
     ) -> None:
         """Test a plot call with an unknown backend plot type.
 
@@ -753,19 +791,24 @@ class TestRasterPop:
             area of interest polygon for dummy data.
         xarr_1_uc : tuple
             urban centre polygon for dummy data.
+        which
+            see `RasterPop.plot()` docstring
+        save
+            see `RasterPop.plot()` docstring
+        expected : Type[RaisesContext]
+            Expected raise result.
+
+        Note
+        ----
+        1. For more information on the other parameters used in this test see
+        the `plot()` docstring. Avoiding duplication by not describing or type
+        hinting them here.
 
         """
         rp = RasterPop(xarr_1_fpath)
         rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
-        unknown_plot_backend = "unknown"
-        with pytest.raises(
-            ValueError,
-            match=(
-                f"Unrecognised value for `which` {unknown_plot_backend}. "
-                "Must be one of "
-            ),
-        ):
-            rp.plot(which=unknown_plot_backend)
+        with expected:
+            rp.plot(which=which, save=save)
 
     def test_plot_foliumn_no_uc(
         self,

--- a/tests/population/test_rasterpop.py
+++ b/tests/population/test_rasterpop.py
@@ -953,3 +953,215 @@ class TestRasterPop:
                 which="cartopy",
                 attr_location=test_attr_location,
             )
+
+    @pytest.mark.parametrize(
+        "figsize, map_tile_zoom, cmap, cbar_fraction, cbar_pad, cbar_label, "
+        "var_attr, base_map_attr, attr_font_size, attr_location, expected",
+        [
+            # test figsize incorrect type
+            (
+                1.0,
+                1,
+                "",
+                1.0,
+                1.0,
+                "",
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`figsize` expected .*tuple.*. Got .*float.*",
+                ),
+            ),
+            # test map_tile_zoom incorrect type
+            (
+                (1.0, 1.0),
+                1.0,
+                "",
+                1.0,
+                1.0,
+                "",
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`map_tile_zoom` expected .*int.*. Got .*float.*",
+                ),
+            ),
+            # test cmap incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                1.0,
+                1.0,
+                1.0,
+                "",
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`cmap` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test cbar_fraction incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                "",
+                1.0,
+                "",
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`cbar_fraction` expected .*float.*. Got .*str.*",
+                ),
+            ),
+            # test cbar_pad incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                1.0,
+                "",
+                "",
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`cbar_pad` expected .*float.*. Got .*str.*",
+                ),
+            ),
+            # test cbar_label incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                1.0,
+                1.0,
+                1.0,
+                "",
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`cbar_label` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test var_attr incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                1.0,
+                1.0,
+                "",
+                1.0,
+                "",
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`var_attr` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test base_map_attr incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                1.0,
+                1.0,
+                "",
+                "",
+                1.0,
+                1.0,
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`base_map_attr` expected .*str.*. Got .*float.*",
+                ),
+            ),
+            # test attr_font_size incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                1.0,
+                1.0,
+                "",
+                "",
+                "",
+                "1.0",
+                "",
+                pytest.raises(
+                    TypeError,
+                    match="^`attr_font_size` expected .*float.*. Got .*str.*",
+                ),
+            ),
+            # test attr_location incorrect type
+            (
+                (1.0, 1.0),
+                1,
+                "",
+                1.0,
+                1.0,
+                "",
+                "",
+                "",
+                1.0,
+                1.0,
+                pytest.raises(
+                    TypeError,
+                    match="^`attr_location` expected .*str.*. Got .*float.*",
+                ),
+            ),
+        ],
+    )
+    def test_plot_cartopy_type_defence(
+        self,
+        xarr_1_fpath,
+        xarr_1_aoi,
+        xarr_1_uc,
+        figsize,
+        map_tile_zoom,
+        cmap,
+        cbar_fraction,
+        cbar_pad,
+        cbar_label,
+        var_attr,
+        base_map_attr,
+        attr_font_size,
+        attr_location,
+        expected: Type[RaisesContext],
+    ) -> None:
+        """Unit test _plot_cartop() kwargs type raises."""
+        rp = RasterPop(xarr_1_fpath)
+        rp.get_pop(xarr_1_aoi[0], urban_centre_bounds=xarr_1_uc[0])
+        with expected:
+            rp.plot(
+                which="cartopy",
+                save=None,
+                figsize=figsize,
+                map_tile_zoom=map_tile_zoom,
+                cmap=cmap,
+                cbar_fraction=cbar_fraction,
+                cbar_pad=cbar_pad,
+                cbar_label=cbar_label,
+                var_attr=var_attr,
+                base_map_attr=base_map_attr,
+                attr_font_size=attr_font_size,
+                attr_location=attr_location,
+            )


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Brings `population` module up to speed with `defence.py` functions.

Closes #54, Closes #56. Also indirectly fixes #53 - not original intention of PR, but bringing it up to speed with `defense.py` fixes the issue.

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
`population` module was written before `defense.py` existed. The changes made in this PR aim to bring `population` inline with these defensive functions, to improve the `population` module. It also improves the unit testing, to assert the expected function argument types for public facing class methods.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

All changes have been tested locally, to ensure the expected raises are triggered. New, passing, unit tests have also been added to reflect these changes.

Test configuration details:
* OS: macOS
* Python version: 3.9.13
* Java version: 11
* Python management system: conda/pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

A breaking change is being introduced into dev that will likely cause `population` unit tests to fail when merging to dev. This needs to be resolved before merging.

I would also appreciate your opinion of the regexs used within the `match` argument of `pytest.raises` calls here. I believe they are such that it's a good balance between capturing the key aspects, being robust to changes in raises statements, and not using the expected raise statement verbatum - which would make the tests very rigid and more difficult to maintain. If you think this compromise is not good, do say and I'm happy to change it. 

Note: type/input checking of arguments has only been added to public facing class methods, not internal methods or kwargs (type checking kwarg arguments would be subject to any external packages). If there are any 'key' kwarg variables you'd prefer to have type checked please say.

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
> Note: this last point needs to be resolved before merging.

## Additional comments
<!--- Add any additional comments here --->
None.