### PR TITLE
70 optional arg for viz stops to only plot stop ids in stop timestxt

### DIFF
--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -361,9 +361,8 @@ class GtfsInstance:
 
         # geoms defence
         geoms = geoms.lower().strip()
-        accept_vals = ["point", "hull"]
-        if geoms not in accept_vals:
-            raise ValueError("`geoms` must be either 'point' or 'hull.'")
+        ACCEPT_VALS = ["point", "hull"]
+        _check_item_in_list(geoms, ACCEPT_VALS, "geoms")
 
         try:
             m = self._produce_stops_map(

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -274,7 +274,7 @@ class GtfsInstance:
         filtered_only: bool
             When True, only stops referenced within stop_times.txt will be
             plotted. When False, stops referenced in stops.txt will be plotted.
-            Note that osmosis filtering behaviour removes stops from
+            Note that gtfs_kit filtering behaviour removes stops from
             stop_times.txt but not stops.txt.
 
         Returns

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -317,20 +317,16 @@ class GtfsInstance:
         out_pth : str
             Path to write the map file html document to, including the file
             name. Must end with '.html' file extension.
-
         geoms : str
             Type of map to plot. If `geoms=point` (the default) uses `gtfs_kit`
             to map point locations of available stops. If `geoms=hull`,
             calculates the convex hull & its area. Defaults to "point".
-
         geom_crs : (str, int)
             Geometric CRS to use for the calculation of the convex hull area
             only. Defaults to "27700" (OSGB36, British National Grid).
-
         create_out_parent : bool
             Should the parent directory of `out_pth` be created if not found.
             Defaults to False.
-
         filtered_only: bool
             When True, only stops referenced within stop_times.txt will be
             plotted. When False, stops referenced in stops.txt will be plotted.

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -273,13 +273,15 @@ class GtfsInstance:
         elif what_geoms == "hull":
             if is_filtered:
                 # filter the stops table to only those stop_ids present
-                # in stop_times, ensures hull viz agrees with point viz
+                # in stop_times, this ensures hull viz agrees with point viz
                 stop_time_ids = set(self.feed.stop_times["stop_id"])
-                key_search = self.feed.stops["stop_id"].isin(stop_time_ids)
-                self.feed.stops = self.feed.stops[key_search]
-
+                gtfs_hull = self.feed.compute_convex_hull(
+                    stop_ids=stop_time_ids
+                )
+            else:
+                # if not filtering, use gtfs_kit method
+                gtfs_hull = self.feed.compute_convex_hull()
             # visualise feed, output to file with area est, based on stops
-            gtfs_hull = self.feed.compute_convex_hull()
             gdf = gpd.GeoDataFrame(
                 {"geometry": gtfs_hull}, index=[0], crs="epsg:4326"
             )

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -320,7 +320,11 @@ class TestGtfsInstance(object):
         ):
             gtfs_fixture.viz_stops(out_pth=tmp, geoms=38)
         with pytest.raises(
-            ValueError, match="`geoms` must be either 'point' or 'hull."
+            ValueError,
+            match=re.escape(
+                "'geoms' expected one of the following:"
+                "['point', 'hull'] Got foobar"
+            ),
         ):
             gtfs_fixture.viz_stops(out_pth=tmp, geoms="foobar")
         with pytest.raises(

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -308,11 +308,15 @@ class TestGtfsInstance(object):
         tmp = os.path.join(tmpdir, "somefile.html")
         with pytest.raises(
             TypeError,
-            match="`out_pth` expected path-like, found <class 'bool'>",
+            match=re.escape(
+                "`out_pth` expected (<class 'str'>, <class 'pathlib.Path'>). "
+                "Got <class 'bool'>"
+            ),
         ):
             gtfs_fixture.viz_stops(out_pth=True)
         with pytest.raises(
-            TypeError, match="`geoms` expects a string. Found <class 'int'>"
+            TypeError,
+            match="`geoms` expected <class 'str'>. Got <class 'int'>",
         ):
             gtfs_fixture.viz_stops(out_pth=tmp, geoms=38)
         with pytest.raises(
@@ -321,7 +325,10 @@ class TestGtfsInstance(object):
             gtfs_fixture.viz_stops(out_pth=tmp, geoms="foobar")
         with pytest.raises(
             TypeError,
-            match="`geom_crs`.*string or integer. Found <class 'float'>",
+            match=re.escape(
+                "`geoms_crs` expected (<class 'str'>, <class 'int'>). Got "
+                "<class 'float'>"
+            ),
         ):
             gtfs_fixture.viz_stops(out_pth=tmp, geom_crs=1.1)
         # check missing stop_id results in an informative error message
@@ -332,7 +339,7 @@ class TestGtfsInstance(object):
             "this is an optional field in a GTFS file, it "
             "raises an error through the gtfs-kit package.",
         ):
-            gtfs_fixture.viz_stops(out_pth=tmp)
+            gtfs_fixture.viz_stops(out_pth=tmp, filtered_only=False)
 
     @patch("builtins.print")
     def test_viz_stops_point(self, mock_print, tmpdir, gtfs_fixture):

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -384,9 +384,11 @@ class TestGtfsInstance(object):
         """Check viz_stops behaviour when plotting hull geom."""
         tmp = os.path.join(tmpdir, "hull.html")
         gtfs_fixture.viz_stops(out_pth=pathlib.Path(tmp), geoms="hull")
-        assert os.path.exists(
-            tmp
-        ), f"Map should have been written to {tmp} but was not found."
+        assert os.path.exists(tmp), f"Map file not found at {tmp}."
+        # assert file created when not filtering the hull
+        tmp1 = os.path.join(tmpdir, "filtered_hull.html")
+        gtfs_fixture.viz_stops(out_pth=tmp1, geoms="hull", filtered_only=False)
+        assert os.path.exists(tmp1), f"Map file not found at {tmp1}."
 
     def test__create_map_title_text_defence(self, gtfs_fixture):
         """Test the defences for _create_map_title_text()."""


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
`GtfsInstance.viz_stops()` has an additional parameter `filtered_only=True` by default. This method will now write a HTML file based on the `stop_id`s appearing in the stop_times.txt only. Setting `filtered_only=False` returns the previous behaviour of plotting all `stop_id`s referenced within stops.txt.

Fixes #70 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
* After the feed is filtered using gtfs_kit, visualise only the points referenced within stop_times.
* Hull and point visualisations should agree.
* Refactoring has brought the `viz_stops` method up to date with defence utils.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: macos
* Python version: 3.9.13
* Java version: openjdk 11.0.19 2023-04-18 LTS
* Python management system: pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->
Advise running the following commands and checking the behaviour is consistent:
```
from transport_performance.gtfs.validation import GtfsInstance
out = "some_filenm.html"
feed = GtfsInstance()
feed.viz_stops(out)
# 1. View some_filenm.html to observe smaller subset of stops in a points map
feed.viz_stops(out, filtered_only=False)
# 2. View some_filenm.html to observe larger subset of stops in a points map
feed.viz_stops(out, geoms="hull")
# 3. View some_filenm.html to observe smaller subset of stops in a hull map
feed.viz_stops(out, geoms="hull")
# 4. View some_filenm.html to observe larger subset of stops in a hull map

"""Points 2 and 4 confirm that `GtfsInstance.feed.stops` table has not dropped rows where
`stop_id` does not appear within stop_times.txt"""



```


## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
