### PR TITLE
131 readable route types

### DIFF
--- a/src/transport_performance/gtfs/report/report_utils.py
+++ b/src/transport_performance/gtfs/report/report_utils.py
@@ -10,40 +10,6 @@ from transport_performance.utils.defence import (
     _check_parent_dir_exists,
 )
 
-# Constant to remove non needed columns from repeated
-# pair error information.
-# This is a messy method however it is the only
-# way to ensure that the error report remains
-# dynamic and can adadpt to different tables
-# in the GTFS file.
-
-GTFS_UNNEEDED_COLUMNS = {
-    "routes": [],
-    "agency": ["agency_phone", "agency_lang"],
-    "stop_times": [
-        "stop_headsign",
-        "pickup_type",
-        "drop_off_type",
-        "shape_dist_traveled",
-        "timepoint",
-    ],
-    "stops": [
-        "wheelchair_boarding",
-        "location_type",
-        "parent_station",
-        "platform_code",
-    ],
-    "calendar_dates": [],
-    "calendar": [],
-    "trips": [
-        "trip_headsign",
-        "block_id",
-        "shape_id",
-        "wheelchair_accessible",
-    ],
-    "shapes": [],
-}
-
 
 class TemplateHTML:
     """A class for inserting HTML string into a template.

--- a/src/transport_performance/gtfs/routes.py
+++ b/src/transport_performance/gtfs/routes.py
@@ -158,14 +158,22 @@ def get_saved_route_type_lookup(
         The route type lookup
 
     """
+    # defences
     _is_expected_filetype(
         pth=path, param_nm="path", check_existing=True, exp_ext=".pkl"
     )
     lookup = pd.read_pickle(path)
-    if len(lookup) < 1:
-        warnings.warn(
-            message="Route type lookup is empty. You may need to "
-            "call 'scrape_route_type_lookup()' first"
+    ACCEPTED_TYPES = (dict, pd.DataFrame)
+    # check unserialized .pkl file is of correct type
+    if not isinstance(lookup, ACCEPTED_TYPES):
+        raise TypeError(
+            "Serialized object in specified .pkl file is of type: "
+            f"{type(lookup)}. Expected {ACCEPTED_TYPES}"
         )
+    # convert dicts to pandas df
+    if isinstance(lookup, dict):
+        lookup = pd.DataFrame(lookup)
+    if len(lookup) < 1:
+        warnings.warn("Route type lookup has length of 0", UserWarning)
 
     return lookup

--- a/src/transport_performance/gtfs/routes.py
+++ b/src/transport_performance/gtfs/routes.py
@@ -175,5 +175,12 @@ def get_saved_route_type_lookup(
         lookup = pd.DataFrame(lookup)
     if len(lookup) < 1:
         warnings.warn("Route type lookup has length of 0", UserWarning)
+    EXPECTED_COLS = ["route_type", "desc"]
+    # check columns
+    for col in lookup.columns.values:
+        if col.lower() not in EXPECTED_COLS:
+            warnings.warn(
+                f"Unexpected column '{col}' in route type lookup", UserWarning
+            )
 
     return lookup

--- a/src/transport_performance/gtfs/routes.py
+++ b/src/transport_performance/gtfs/routes.py
@@ -3,8 +3,14 @@ import pandas as pd
 from bs4 import BeautifulSoup
 import requests
 import warnings
+from typing import Union
+import pathlib
 
-from transport_performance.utils.defence import _url_defence, _type_defence
+from transport_performance.utils.defence import (
+    _url_defence,
+    _type_defence,
+    _is_expected_filetype,
+)
 
 warnings.filterwarnings(
     action="ignore", category=DeprecationWarning, module=".*pkg_resources"
@@ -131,3 +137,35 @@ def scrape_route_type_lookup(
     route_lookup = pd.DataFrame(zip(cds, txts), columns=["route_type", "desc"])
 
     return route_lookup
+
+
+def get_saved_route_type_lookup(
+    path: Union[str, pathlib.Path] = pathlib.Path(
+        "tests/data/gtfs/route_lookup.pkl"
+    )
+) -> pd.DataFrame:
+    """Get the lcoally saved route type lookup as a dataframe.
+
+    Parameters
+    ----------
+    path : Union[str, pathlib.Path], optional
+        The path to the route type lookup,
+        by default pathlib.Path("tests/data/gtfs/route_lookup.pkl")
+
+    Returns
+    -------
+    pd.DataFrame
+        The route type lookup
+
+    """
+    _is_expected_filetype(
+        pth=path, param_nm="path", check_existing=True, exp_ext=".pkl"
+    )
+    lookup = pd.read_pickle(path)
+    if len(lookup) < 1:
+        warnings.warn(
+            message="Route type lookup is empty. You may need to "
+            "call 'scrape_route_type_lookup()' first"
+        )
+
+    return lookup

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -34,7 +34,6 @@ from transport_performance.utils.defence import (
 from transport_performance.gtfs.report.report_utils import (
     TemplateHTML,
     _set_up_report_dir,
-    GTFS_UNNEEDED_COLUMNS,
 )
 
 
@@ -168,6 +167,39 @@ class GtfsInstance:
         self.feed = gk.read_feed(gtfs_pth, dist_units=units)
         self.gtfs_path = gtfs_pth
         self.ROUTE_LKP = get_saved_route_type_lookup()
+        # Constant to remove non needed columns from repeated
+        # pair error information.
+        # This is a messy method however it is the only
+        # way to ensure that the error report remains
+        # dynamic and can adadpt to different tables
+        # in the GTFS file.
+
+        self.GTFS_UNNEEDED_COLUMNS = {
+            "routes": [],
+            "agency": ["agency_phone", "agency_lang"],
+            "stop_times": [
+                "stop_headsign",
+                "pickup_type",
+                "drop_off_type",
+                "shape_dist_traveled",
+                "timepoint",
+            ],
+            "stops": [
+                "wheelchair_boarding",
+                "location_type",
+                "parent_station",
+                "platform_code",
+            ],
+            "calendar_dates": [],
+            "calendar": [],
+            "trips": [
+                "trip_headsign",
+                "block_id",
+                "shape_id",
+                "wheelchair_accessible",
+            ],
+            "shapes": [],
+        }
 
     def get_gtfs_files(self) -> list:
         """Return a list of files making up the GTFS file.
@@ -1036,7 +1068,7 @@ class GtfsInstance:
                 )
                 drop_cols = [
                     col
-                    for col in GTFS_UNNEEDED_COLUMNS[table]
+                    for col in self.GTFS_UNNEEDED_COLUMNS[table]
                     if col not in join_vars
                 ]
                 filtered_tbl = table_map[table].copy().drop(drop_cols, axis=1)

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -179,6 +179,7 @@ class GtfsInstance:
 
         self.feed = gk.read_feed(gtfs_pth, dist_units=units)
         self.gtfs_path = gtfs_pth
+        self.ROUTE_LKP = get_saved_route_type_lookup()
 
     def get_gtfs_files(self) -> list:
         """Return a list of files making up the GTFS file.
@@ -854,10 +855,9 @@ class GtfsInstance:
         _check_column_in_df(df=summary_df, column_name=day_column)
 
         # convert column type for better graph plotting, use desc
-        ROUTE_LKP = get_saved_route_type_lookup()
         summary_df["route_type"] = summary_df["route_type"].astype("object")
         summary_df["route_type"] = summary_df["route_type"].apply(
-            lambda x: _get_route_type_desc(ROUTE_LKP, x)
+            lambda x: _get_route_type_desc(self.ROUTE_LKP, x)
         )
 
         xlabel = (
@@ -1109,13 +1109,12 @@ class GtfsInstance:
 
             # add a more detailed route_type decription
             if "route_type" in impacted_rows.columns:
-                ROUTE_LKP = get_saved_route_type_lookup()
                 impacted_rows["route_type"] = impacted_rows[
                     "route_type"
                 ].astype("object")
                 impacted_rows["route_type_desc"] = impacted_rows[
                     "route_type"
-                ].apply(lambda x: _get_route_type_desc(ROUTE_LKP, x))
+                ].apply(lambda x: _get_route_type_desc(self.ROUTE_LKP, x))
 
             table_html = table_html + build_table(
                 impacted_rows, scheme, padding="10px", escape=False

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -145,6 +145,7 @@ def _convert_multi_index_to_single(df: pd.DataFrame) -> pd.DataFrame:
 
 def _get_route_type_desc(lkp, key):
     """Private function to get route type description."""
+    # no defences as private and only intended to be used internally
     try:
         desc = list(lkp[lkp.route_type == str(key)].desc)[0]
         # only take transport method name
@@ -1103,6 +1104,16 @@ class GtfsInstance:
                 table_html = table_html + "</div>"
             except NameError:
                 pass
+
+            # add a more detailed route_type decription
+            if "route_type" in impacted_rows.columns:
+                ROUTE_LKP = get_saved_route_type_lookup()
+                impacted_rows["route_type"] = impacted_rows[
+                    "route_type"
+                ].astype("object")
+                impacted_rows["route_type_desc"] = impacted_rows[
+                    "route_type"
+                ].apply(lambda x: _get_route_type_desc(ROUTE_LKP, x))
 
             table_html = table_html + build_table(
                 impacted_rows, scheme, padding="10px", escape=False

--- a/tests/gtfs/test_routes.py
+++ b/tests/gtfs/test_routes.py
@@ -7,6 +7,8 @@ from typing import Union, Type
 import pathlib
 from _pytest.python_api import RaisesContext
 import re
+import pickle
+import os
 
 
 from transport_performance.gtfs.routes import (
@@ -135,12 +137,23 @@ class TestScrapeRouteTypeLookup(object):
         pd.testing.assert_frame_equal(lookup, lookup_fix)
 
 
+def _create_pkl(obj, out_pth: Union[str, pathlib.Path]) -> None:
+    """Private function used to create .pkl. Not exported."""
+    # NOTE: not including defences as this is a private function that is only
+    # used for testing
+    with open(out_pth, "wb") as f:
+        pickle.dump(obj, f)
+
+    return None
+
+
 class Test_GetSavedRouteTypeLookup(object):
     """Tests for get_saved_route_type_lookup()."""
 
     @pytest.mark.parametrize(
         "path, expected",
         [
+            # test raises from key _is_expected_filetype() defences
             (
                 pathlib.Path("tests/data/newport-20230613_gtfs.zip"),
                 pytest.raises(
@@ -167,3 +180,74 @@ class Test_GetSavedRouteTypeLookup(object):
         """Test raises."""
         with expected:
             get_saved_route_type_lookup(path=path)
+
+    @pytest.mark.parametrize(
+        "pkl_name, test_obj, expected",
+        [
+            # invalid object once .pkl unserialized
+            (
+                "list_pkl.pkl",
+                [1, 2, 3, 4, 5],
+                pytest.raises(
+                    TypeError,
+                    match=re.escape(
+                        "Serialized object in specified .pkl file is of type: "
+                        "<class 'list'>. Expected (<class 'dict'>, "
+                        "<class 'pandas.core.frame.DataFrame'>)"
+                    ),
+                ),
+            ),
+            # empty dataframe
+            (
+                "empty_pkl.pkl",
+                pd.DataFrame({"test_col": []}),
+                pytest.warns(
+                    UserWarning, match="Route type lookup has length of 0"
+                ),
+            ),
+            # df with invalid columns
+            (
+                "invalid_col_pkl.pkl",
+                pd.DataFrame(
+                    {"route_type": [0, 1], "route_desc": ["car", "bus"]}
+                ),
+                pytest.warns(
+                    UserWarning,
+                    match=(
+                        "Unexpected column 'route_desc' in route type lookup"
+                    ),
+                ),
+            ),
+        ],
+    )
+    def test_get_saved_route_type_lookup_invalid_pkl(
+        self, tmp_path, pkl_name, test_obj, expected
+    ):
+        """Test defences when unserialized pickle is invalid obj type."""
+        out_pth = os.path.join(tmp_path, pkl_name)
+        _create_pkl(obj=test_obj, out_pth=out_pth)
+        with expected:
+            get_saved_route_type_lookup(out_pth)
+
+    def test_get_saved_route_type_lookup_on_pass(self, tmp_path):
+        """Test get_saved_route_type_lookup_on_pass()."""
+        found_lkp = get_saved_route_type_lookup()
+        assert isinstance(found_lkp, pd.DataFrame), ".pkl did not return df"
+        assert len(found_lkp) == 91, ".pkl is an unexpected length"
+        assert list(found_lkp.columns) == [
+            "route_type",
+            "desc",
+        ], ".pkl columns are not as expected"
+        # test a .pkl containing a serialized dict
+        test_dict = {"route_type": [0, 1, 2], "desc": ["bus", "train", "car"]}
+        out_pth = os.path.join(tmp_path, "dict_pkl.pkl")
+        _create_pkl(test_dict, out_pth=out_pth)
+        dict_lkp = get_saved_route_type_lookup(path=out_pth)
+        assert isinstance(
+            dict_lkp, pd.DataFrame
+        ), "Dict pkl did not convert to pd.DataFrame"
+        assert len(dict_lkp) == 3, "Dict .pkl length not as expected"
+        assert list(dict_lkp.columns) == [
+            "route_type",
+            "desc",
+        ], ".pkl columns are not as expected"

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -17,9 +17,7 @@ from transport_performance.gtfs.validation import (
     _get_intermediate_dates,
     _create_map_title_text,
     _convert_multi_index_to_single,
-    _get_route_type_desc,
 )
-from transport_performance.gtfs.routes import get_saved_route_type_lookup
 
 
 @pytest.fixture(scope="function")  # some funcs expect cleaned feed others dont
@@ -450,18 +448,6 @@ class TestGtfsInstance(object):
             assert col in expected_cols, f"{col} not an expected column"
             expected_cols.remove(col)
         assert len(expected_cols) == 0, "Not all expected cols in output cols"
-
-    def test__get_route_type_desc(self):
-        """Tests for _get_route_type_desc()."""
-        route_lkp = get_saved_route_type_lookup()
-        assert (
-            _get_route_type_desc(route_lkp, 3) == "Bus"
-        ), "Failed to get route type description"
-        # test if route_type isn't present
-        route_lkp = route_lkp[route_lkp["route_type"] != "3"]
-        assert (
-            _get_route_type_desc(route_lkp, 3) == 3
-        ), "Getting route type desc when route type not present failed"
 
     def test__order_dataframe_by_day_defence(self, gtfs_fixture):
         """Test __order_dataframe_by_day defences."""

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -17,7 +17,9 @@ from transport_performance.gtfs.validation import (
     _get_intermediate_dates,
     _create_map_title_text,
     _convert_multi_index_to_single,
+    _get_route_type_desc,
 )
+from transport_performance.gtfs.routes import get_saved_route_type_lookup
 
 
 @pytest.fixture(scope="function")  # some funcs expect cleaned feed others dont
@@ -448,6 +450,18 @@ class TestGtfsInstance(object):
             assert col in expected_cols, f"{col} not an expected column"
             expected_cols.remove(col)
         assert len(expected_cols) == 0, "Not all expected cols in output cols"
+
+    def test__get_route_type_desc(self):
+        """Tests for _get_route_type_desc()."""
+        route_lkp = get_saved_route_type_lookup()
+        assert (
+            _get_route_type_desc(route_lkp, 3) == "Bus"
+        ), "Failed to get route type description"
+        # test if route_type isn't present
+        route_lkp = route_lkp[route_lkp["route_type"] != "3"]
+        assert (
+            _get_route_type_desc(route_lkp, 3) == 3
+        ), "Getting route type desc when route type not present failed"
 
     def test__order_dataframe_by_day_defence(self, gtfs_fixture):
         """Test __order_dataframe_by_day defences."""


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
This PR introduces a new function that allows you to obtain the route type lookup without scraping (from tests/data/gtfs/route_lookup.pkl). This then allows for better route_type descriptions to be used in the HTML report for `GtfsInstance()`.

Fixes #131 


## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Wiindows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: Conda

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
