### PR TITLE
55 enforce file extensions

### DIFF
--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -21,6 +21,7 @@ from transport_performance.utils.defence import (
     _type_defence,
     _handle_path_like,
     _check_parent_dir_exists,
+    _enforce_file_extension,
 )
 
 
@@ -513,6 +514,18 @@ class RasterPop:
         # write to file if filepath is given
         if save is not None:
             _check_parent_dir_exists(save, "save", create=True)
+            # get file extension for a more detailed error msg
+            root, ext = os.path.splitext(save)
+            save = _enforce_file_extension(
+                save,
+                ".html",
+                ".html",
+                "save",
+                msg=(
+                    f"Format '{ext}' not implemented. Writing folium"
+                    "map as '.html'"
+                ),
+            )
             m.save(save)
             m = None
 
@@ -696,6 +709,18 @@ class RasterPop:
         # get the current figure and resize it to match the axis before saving
         if save is not None:
             _check_parent_dir_exists(save, "save", create=True)
+            # get extension for error messge
+            root, ext = os.path.splitext(save)
+            save = _enforce_file_extension(
+                save,
+                ".png",
+                ".png",
+                "save",
+                msg=(
+                    f"Format '{ext}' not implemented. Writing cartopy plot"
+                    " as '.png'"
+                ),
+            )
             fig = plt.gcf()
             fig.set_size_inches(*figsize)
             fig.savefig(save)
@@ -738,6 +763,18 @@ class RasterPop:
         # write to file if filepath is given
         if save is not None:
             _check_parent_dir_exists(save, "save", create=True)
+            # get extension for error messge
+            root, ext = os.path.splitext(save)
+            save = _enforce_file_extension(
+                save,
+                ".png",
+                ".png",
+                "save",
+                msg=(
+                    f"Format '{ext}' not implemented. Writing matplotlib plot"
+                    " as '.png'"
+                ),
+            )
             fig.savefig(save)
             ax = None
 

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -705,6 +705,12 @@ class RasterPop:
         # use tight layout to maximise axis size of axis
         plt.tight_layout()
 
+        # list of allowed formats to save plot
+        formats = [
+            "." + n
+            for n in list(plt.gcf().canvas.get_supported_filetypes().keys())
+        ]
+
         # write to file if filepath is given, since there is no figure, need to
         # get the current figure and resize it to match the axis before saving
         if save is not None:
@@ -713,7 +719,7 @@ class RasterPop:
             root, ext = os.path.splitext(save)
             save = _enforce_file_extension(
                 save,
-                ".png",
+                formats,
                 ".png",
                 "save",
                 msg=(
@@ -760,6 +766,12 @@ class RasterPop:
         self._xds.plot(ax=ax)
         plt.tight_layout()
 
+        # list of allowed formats to save plot
+        formats = [
+            "." + n
+            for n in list(plt.gcf().canvas.get_supported_filetypes().keys())
+        ]
+
         # write to file if filepath is given
         if save is not None:
             _check_parent_dir_exists(save, "save", create=True)
@@ -767,7 +779,7 @@ class RasterPop:
             root, ext = os.path.splitext(save)
             save = _enforce_file_extension(
                 save,
-                ".png",
+                formats,
                 ".png",
                 "save",
                 msg=(

--- a/src/transport_performance/population/rasterpop.py
+++ b/src/transport_performance/population/rasterpop.py
@@ -550,8 +550,11 @@ class RasterPop:
         Parameters
         ----------
         save : str, optional
-            Filepath to save location, with ".png" extension, by default None
-            meaning the map will not be saved to file.
+            Filepath to save location, by default None meaning the map will
+            not be saved to file. Accepted formats are 'eps', 'jpg','jpeg',
+            'pdf', 'pgf', 'png', 'ps', 'raw', 'rgba', 'svg', 'svgz', 'tif',
+            'tiff', 'webp'. If any other file extension is given, it will
+            default to '.png'.
         figsize : tuple, optional
             The matplotlib figure size width and height in inches, by default
             (10, 8).
@@ -745,8 +748,11 @@ class RasterPop:
         Parameters
         ----------
         save : str, optional
-            Filepath to save location, with ".png" extension, by default None
-            meaning the plot will not be saved to file.
+            Filepath to save location, by default None meaning the map will
+            not be saved to file. Accepted formats are 'eps', 'jpg','jpeg',
+            'pdf', 'pgf', 'png', 'ps', 'raw', 'rgba', 'svg', 'svgz', 'tif',
+            'tiff', 'webp'. If any other file extension is given, it will
+            default to '.png'.
         figsize : tuple, optional
             The matplotlib figursize width and height in inches, by default
             (6.4, 4.8).

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -389,12 +389,12 @@ def _enforce_file_extension(
     root, ext = os.path.splitext(path)
     if isinstance(exp_ext, str):
         exp_ext = [exp_ext]
-    if ext.lower not in exp_ext:
+    if ext.lower() not in exp_ext:
         # format warning message
         if not msg:
             msg = (
                 f"Format {ext} provided. Expected {exp_ext} for path given "
-                f"{param_nm}"
+                f"to '{param_nm}'"
             )
         # warn user
         warnings.warn(msg, UserWarning)

--- a/src/transport_performance/utils/defence.py
+++ b/src/transport_performance/utils/defence.py
@@ -306,7 +306,7 @@ def _check_item_in_list(item: str, _list: list, param_nm: str) -> None:
     Parameters
     ----------
     item : str
-        THe item to check the list for
+        The item to check the list for
     _list : list
         The list to check that the item is in
     param_nm : str
@@ -356,3 +356,47 @@ def _check_attribute(obj, attr: str, message: str = None):
 
     if attr not in obj.__dir__():
         raise AttributeError(err_msg)
+
+
+def _enforce_file_extension(
+    path: Union[str, pathlib.Path],
+    exp_ext: Union[str, list],
+    default_ext: str,
+    param_nm: str,
+    msg: str = None,
+) -> pathlib.Path:
+    """Defensive check for enforcing file extensions.
+
+    Parameters
+    ----------
+    path : Union[str, pathlib.Path]
+        The filepath to check the extension of.
+    exp_ext : Union[str, list]
+        The expected/implemented extension(s)
+    default_ext : str
+        The extensions to default to if the extension is invalid
+    param_nm : str
+        The name of the parameter that the path was passed to
+    msg : str, optional
+        Custom error message to display, by default None
+
+    Returns
+    -------
+    pathlib.Path
+        The path with the correct file extension
+
+    """
+    root, ext = os.path.splitext(path)
+    if isinstance(exp_ext, str):
+        exp_ext = [exp_ext]
+    if ext.lower not in exp_ext:
+        # format warning message
+        if not msg:
+            msg = (
+                f"Format {ext} provided. Expected {exp_ext} for path given "
+                f"{param_nm}"
+            )
+        # warn user
+        warnings.warn(msg, UserWarning)
+        path = os.path.normpath(root + default_ext)
+    return pathlib.Path(path)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
This issue aims to enforce file extensions in the `.plot()` backends in the `RasterPop` class.  
In order to achieve this, a new defensive function was created to be used throughout the package. This can be found in `defence.py`

Fixes #55 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Windows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: Conda

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
