### PR TITLE
19 pkg resources deprecation warning

### DIFF
--- a/.github/workflows/all-os-tests.yml
+++ b/.github/workflows/all-os-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11.0"]
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/all-os-tests.yml
+++ b/.github/workflows/all-os-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11.0"]
+        python-version: ["3.11.6"]
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/all-os-tests.yml
+++ b/.github/workflows/all-os-tests.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install .
     - name: Run Integration Tests  # run only those tests marked runinteg & with no osmosis deps
       run: |
           pytest -m runinteg --runinteg --deselect tests/osm/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .
     - name: Install java
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11.0"]
         os: ["macos-latest", "ubuntu-latest"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11.0"]
+        python-version: ["3.11.6"]
         os: ["macos-latest", "ubuntu-latest"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sphinx-render.yml
+++ b/.github/workflows/sphinx-render.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .
     - name: Sphinx build  # use -W to turn warnings into errors
       run: |
         make -C docs/ html SPHINXOPTS="-W"

--- a/.github/workflows/sphinx-render.yml
+++ b/.github/workflows/sphinx-render.yml
@@ -3,7 +3,7 @@ name: "Render docs"
 on: push
 
 env:
-  PYTHON_VERSION: "3.11.0"
+  PYTHON_VERSION: "3.11.6"
   PUSH_BRANCH: "refs/heads/dev"
 
 jobs:

--- a/.github/workflows/sphinx-render.yml
+++ b/.github/workflows/sphinx-render.yml
@@ -3,7 +3,7 @@ name: "Render docs"
 on: push
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11.0"
   PUSH_BRANCH: "refs/heads/dev"
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ Install Dependencies:
 
 Package set-up and installation:
 
-1. Setup a new conda env: `conda create -n r5py python=3.9.13`
-2. Activate the environment: `conda activate r5py`
+1. Setup a new conda env: `conda env create -f environment.yml`
+2. Activate the environment: `conda activate transport-performance`
 3. Launch terminal and change directory to wherever you keep your GitHub repos: `cd ~/Documents`
 4. Clone this repo, eg with https: `git clone https://github.com/datasciencecampus/transport-network-performance.git`
 5. Change directory to the repo: `cd transport-network-performance`

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: transport-performance
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11.0
+  - cartopy
+  - proj # Required to build cartopy (can't be installed with pip)
+# create your environment with the below line
+# conda env create -f environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: transport-performance
 channels:
   - conda-forge
 dependencies:
-  - python=3.11.0
+  - python=3.11.6
   - cartopy
   - proj # Required to build cartopy (can't be installed with pip)
 # create your environment with the below line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=61.0.0", "wheel"]
+requires = ["setuptools==65.6.3", "wheel"]
 
 [project]
 name = "transport_performance"
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: MacOS",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.9, <3.10"
+requires-python = "==3.11.0"
 version = "0.0.1"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: MacOS",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = "==3.11.0"
+requires-python = "==3.11.6"
 version = "0.0.1"
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,22 @@
-pre-commit
-r5py==0.1.0
-gtfs_kit==5.2.7
-rasterio
-matplotlib>=3.7.0
-scipy
-rioxarray
-geopandas
-geocube
-pyproj>=3.6.0
-pytest
+beautifulsoup4
+cartopy
 coverage
+numpy>=1.25.0 # test suite will fail if user installed lower than this
+geocube
+gtfs_kit==5.2.7
+ipykernel==6.23.1
+kaleido
+mapclassify
+munkres # new parent import flagged pipdeptools
+nbformat
+plotly
+pre-commit
+pretty_html_table
 pyprojroot
 pytest-lazy-fixture
-ipykernel==6.23.1
-pandas<2.1.0
-beautifulsoup4
-requests
 pytest-mock
-toml
-plotly
-nbformat>=4.2.0
+r5py==0.1.0
 scikit-image
-cartopy
-folium
-mapclassify
 seaborn
-pretty_html_table
-kaleido
-numpy>=1.25.0 # test suite will fail if user installed lower than this
-sphinx
 sphinx-rtd-theme
--e .
+toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,5 @@ kaleido
 numpy>=1.25.0 # test suite will fail if user installed lower than this
 sphinx
 sphinx-rtd-theme
+setuptools==65.6.3
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ kaleido
 mapclassify
 munkres # new parent import flagged pipdeptools
 nbformat
+pandas<2.1.0
 plotly
 pre-commit
 pretty_html_table

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,4 @@ kaleido
 numpy>=1.25.0 # test suite will fail if user installed lower than this
 sphinx
 sphinx-rtd-theme
-setuptools==65.6.3
 -e .

--- a/src/transport_performance/gtfs/routes.py
+++ b/src/transport_performance/gtfs/routes.py
@@ -12,12 +12,6 @@ from transport_performance.utils.defence import (
     _is_expected_filetype,
 )
 
-warnings.filterwarnings(
-    action="ignore", category=DeprecationWarning, module=".*pkg_resources"
-)
-# see https://github.com/datasciencecampus/transport-network-performance/
-# issues/19
-
 
 def _construct_extended_schema_table(
     some_soup: BeautifulSoup, cd_list: list, desc_list: list


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Following our discussion about upgrading to python 3.11.x with a stripped back requirements.txt today, I went ahead and decided to implement things. A few things to note here:

* A new explicit dependency as suggested by pipdeptools is [munkres](https://software.clapper.org/munkres/) which seems to be a python internal for resource partition.
* `install -e .` removed from reqs
* Python needs major minor patch to match in pyproject.toml, environment.yml & installs in CI runners
* Local install (not in editable mode) of transport-performance added to all runners
* This approach would tolerate `pkg_resource` deprecation warnings
* A deprecation warning originating from kaleido is introduced

Fixes None

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
Reference for deprecation and future warnings associated with upgrading to python 3.11.6

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Housekeeping

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: macos
* Python version: 3.11.6
* Java version: NA
* Python management system: pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

Warnings introduced on `pytest` are as follows, some of which originate in our source code:

```
================================================================ warnings summary =================================================================
../../../../opt/anaconda3/envs/transport-performance/lib/python3.11/site-packages/pycountry/__init__.py:10
  /opt/anaconda3/envs/transport-performance/lib/python3.11/site-packages/pycountry/__init__.py:10: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../../../opt/anaconda3/envs/transport-performance/lib/python3.11/site-packages/pkg_resources/__init__.py:2871
  /opt/anaconda3/envs/transport-performance/lib/python3.11/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

tests/gtfs/test_validation.py::TestGtfsInstance::test__plot_summary_on_pass
  /opt/anaconda3/envs/transport-performance/lib/python3.11/site-packages/kaleido/scopes/base.py:188: DeprecationWarning:
  
  setDaemon() is deprecated, set the daemon attribute instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

...

tests/gtfs/test_validation.py::TestGtfsInstance::test__plot_summary_on_pass
  /opt/anaconda3/envs/foobar-tp/lib/python3.11/site-packages/kaleido/scopes/base.py:188: DeprecationWarning:
  
  setDaemon() is deprecated, set the daemon attribute instead

tests/urban_centres/test_urban_centres.py::test_final_output
  /Users/richardleyshon/Documents/transport-network-performance/tests/urban_centres/test_urban_centres.py:554: FutureWarning:
  
  Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`

tests/urban_centres/test_urban_centres.py::test_final_output
  /Users/richardleyshon/Documents/transport-network-performance/tests/urban_centres/test_urban_centres.py:564: FutureWarning:
  
  Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`

```

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] **My changes generate no new warnings** See point above
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
