### PR TITLE
230 filter osm input

### DIFF
--- a/src/transport_performance/osm/osm_utils.py
+++ b/src/transport_performance/osm/osm_utils.py
@@ -53,6 +53,9 @@ def filter_osm(
 
     """
     # defence
+    _type_defence(pbf_pth, "pbf_pth", (pathlib.Path, str))
+    # if pbf_pth is str, convert to Path in order to access as_posix method
+    pbf_pth = pathlib.Path(pbf_pth)
     _is_expected_filetype(pbf_pth, param_nm="pbf_pth", exp_ext=".pbf")
     _enforce_file_extension(out_pth, ".pbf", ".pbf", "out_pth")
     for nm, val in {

--- a/tests/osm/test_osm_utils.py
+++ b/tests/osm/test_osm_utils.py
@@ -3,6 +3,9 @@ import pytest
 import os
 from unittest.mock import patch, call
 import re
+import glob
+
+from pyprojroot import here
 
 from transport_performance.osm.osm_utils import filter_osm
 
@@ -118,3 +121,21 @@ class TestFilterOsm(object):
             .startswith("call('Filter completed. Written to ")
         )
         assert out is None
+
+    @pytest.mark.runinteg
+    @patch("builtins.print")
+    def test_filter_osm_takes_globstring(self, mock_print, tmpdir):
+        """Assert filter operation executes when user passes a globstring."""
+        found_pbf = sorted(glob.glob(str(here("tests/data/*.pbf"))))[0]
+        target_pth = os.path.join(tmpdir, "test_globstring_input.osm.pbf")
+        filter_osm(
+            pbf_pth=found_pbf, out_pth=target_pth, install_osmosis=False
+        )
+        # check the file exists
+        assert os.path.exists(
+            target_pth
+        ), f"Filtered pbf file not found: {target_pth}"
+        func_out = mock_print.mock_calls
+        assert (
+            func_out[-1].__str__().endswith("test_globstring_input.osm.pbf')")
+        )


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
small patch - filter_osm now accepts string input. Test to confirm  compatibility with single globstring. 

Fixes #230 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
When the filename of the pbf file is unknown, the user would like to pass a globstring to the function. Strings were previously not handled correctly. This has now been corrected.

## Type of change
<!--- Please select from the options below --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

A new integration test passing a single globstring.

Test configuration details:
* OS: macos
* Python version: 3.9.11
* Java version: 11.0.19
* Python management system: pip

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
