### PR TITLE
Fix summaries in MultiGtfsInstance

### DIFF
--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -399,7 +399,9 @@ class MultiGtfsInstance:
         if not return_summary:
             return daily_schedule
         if not to_days:
-            dated = daily_schedule[["date", "route_type", group_col]]
+            dated = daily_schedule[
+                ["date", "route_type", group_col]
+            ].drop_duplicates()
             dated = dated.groupby(["date", "route_type"]).count().reset_index()
             dated = dated.rename(columns={group_col: count_col})
             dated = dated.sort_values("date")

--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -326,7 +326,7 @@ class TestMultiGtfsInstance(object):
             {
                 "date": ["2023-06-06", "2023-06-06"],
                 "route_type": [3, 200],
-                "route_count": [151, 25],
+                "route_count": [12, 4],
             },
             index=[2, 3],
         )
@@ -368,8 +368,7 @@ class TestMultiGtfsInstance(object):
         )
         assert len(dated_sum) == 590, "Dated route counts not as expected"
         assert (
-            dated_sum[dated_sum.date == "2024-04-06"].route_count.iloc[0]
-            == 159
+            dated_sum[dated_sum.date == "2024-04-06"].route_count.iloc[0] == 9
         ), "Unexpecteed number of routes on 2024-04-06"
 
     def test_summarise_trips(self, multi_gtfs_fixture):


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
This PR fixes an issue where summarise_routes(to_days=False) and summarise_trips(to_days=False) returned identical results. This has been fixed by dropping duplicates.

Fixes #228 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->

## Type of change
<!--- Please select from the options below --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Windows 10
* Python version: 3.9.13
* Java version: n/a
* Python management system: Conda

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
