### PR TITLE
Allow for viz_stops to be used without stop_code column for MGTFS

### DIFF
--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -454,3 +454,11 @@ class TestMultiGtfsInstance(object):
         assert isinstance(returned, folium.Map)
         files = glob.glob(f"{tmp_path}/*.html")
         assert len(files) == 2, "More files saved than expected"
+        # returning a folium map without stop_code present
+        multi_gtfs_fixture.instances[0].feed.stops.drop(
+            "stop_code", axis=1, inplace=True
+        )
+        no_stop_code_map = multi_gtfs_fixture.viz_stops()
+        assert isinstance(
+            no_stop_code_map, folium.Map
+        ), "Map not plotted without stop_code present"


### PR DESCRIPTION
…at: add new tests

## Description
<!--- Please include a summary of the change and which issue is fixed. --->
This PR fixes an issue where `gtfs::multi_validation::MultiGtfsInstance.viz_stops()` can not be used if any of the GTFS are missing a `stop_code` column. This has been fixed by synthesizing a stop_code column if it is not present.

Fixes 
Fixes #234 


## Type of change
<!--- Please select from the options below --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Windows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: Conda



## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
