### PR TITLE
A get_dates() method for MultiGtfsInstance

### DIFF
--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -640,7 +640,8 @@ class MultiGtfsInstance:
         Parameters
         ----------
         return_range : bool, optional
-           Whether to return the raw dates, or the min/max, by default True
+           Whether to return the raw dates, or the min/max range, by default
+           True
 
         Returns
         -------

--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -67,6 +67,8 @@ class MultiGtfsInstance:
         Plot each of the stops from all GtfsInstance's on a folium Map object.
     validate_empty_feeds()
         Check if there are empty feeds within the MultiGtfsInstance.
+    get_dates()
+        Get the range of dates that the gtfs(s) span.
 
     Raises
     ------
@@ -631,3 +633,34 @@ class MultiGtfsInstance:
         if return_viz:
             return map
         return None
+
+    def get_dates(self, return_range: bool = True) -> list:
+        """Get all available dates from calendar.txt (or calendar_dates.txt).
+
+        Parameters
+        ----------
+        return_range : bool, optional
+           Whether to return the raw dates, or the min/max, by default True
+
+        Returns
+        -------
+        list
+            Either the full set of dates, or the range that the dates span
+            between
+
+        """
+        _type_defence(return_range, "return_range", bool)
+        available_dates = set()
+        for inst in self.instances:
+            # gtfs-kit makes calendar None if it isn't present
+            if isinstance(inst.feed.calendar, type(None)):
+                available_dates.update(
+                    inst.feed.calendar_dates["date"].unique()
+                )
+            else:
+                available_dates.update(inst.feed.calendar["start_date"])
+                available_dates.update(inst.feed.calendar["end_date"])
+        sorted_dates = sorted(available_dates)
+        if return_range:
+            return [min(sorted_dates), max(sorted_dates)]
+        return sorted_dates

--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -4,6 +4,7 @@ import os
 import glob
 import pathlib
 import shutil
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -30,6 +31,23 @@ def multi_gtfs_fixture(multi_gtfs_paths):
     """Test fixture for MultiGtfsInstance."""
     m_gtfs = MultiGtfsInstance(multi_gtfs_paths)
     return m_gtfs
+
+
+@pytest.fixture(scope="function")
+def multi_gtfs_altered_fixture(multi_gtfs_fixture):
+    """Test fixture with calendar_dates.txt in GTFS instance 0."""
+    # deepcopy otherwise it overwrites multi_gtfs_fixture
+    mgtfs = deepcopy(multi_gtfs_fixture)
+    dummy_cdates = pd.DataFrame(
+        {
+            "service_id": ["000001", "000001", "000002", "000003"],
+            "date": ["20231211", "20240601", "20240613", "20220517"],
+            "exception_type": [1, 1, 1, 1],
+        }
+    )
+    mgtfs.instances[0].feed.calendar_dates = dummy_cdates
+    mgtfs.instances[0].feed.calendar = None
+    return mgtfs
 
 
 class TestMultiGtfsInstance(object):
@@ -454,3 +472,42 @@ class TestMultiGtfsInstance(object):
         assert isinstance(returned, folium.Map)
         files = glob.glob(f"{tmp_path}/*.html")
         assert len(files) == 2, "More files saved than expected"
+
+    def test_get_dates_defence(self, multi_gtfs_fixture):
+        """Defensive tests for .get_dates()."""
+        with pytest.raises(
+            TypeError, match=".*return_range.*expected.*bool.*Got.*str.*"
+        ):
+            multi_gtfs_fixture.get_dates(return_range="test")
+
+    def test_get_dates(self, multi_gtfs_fixture, multi_gtfs_altered_fixture):
+        """General tests for .get_dates()."""
+        # multi gtfs with only calendar.txt
+        # return_range=True
+        assert (
+            len(multi_gtfs_fixture.get_dates()) == 2
+        ), "Too many dates returned"
+        assert (
+            multi_gtfs_fixture.get_dates()[0] == "20230605"
+        ), "min not as expected"
+        assert (
+            multi_gtfs_fixture.get_dates()[1] == "20240426"
+        ), "max not as expected"
+        # return_range=False
+        assert (
+            len(multi_gtfs_fixture.get_dates(return_range=False)) == 5
+        ), "Unexpected number of dates"
+        # multi_gtfs with both calendar.txt and calendar_dates.txt
+        # return_range=True
+        assert (
+            len(multi_gtfs_altered_fixture.get_dates()) == 2
+        ), "Unexpected number of dates"
+        assert (
+            multi_gtfs_altered_fixture.get_dates()[0] == "20220517"
+        ), "min not as expected"
+        assert multi_gtfs_altered_fixture.get_dates()[1] == "20240613"
+        # return_range=False
+        assert (
+            len(multi_gtfs_altered_fixture.get_dates(return_range=False)) == 6
+        ), "Unexpected number of dates"
+        pass

--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -486,7 +486,7 @@ class TestMultiGtfsInstance(object):
         # return_range=True
         assert (
             len(multi_gtfs_fixture.get_dates()) == 2
-        ), "Too many dates returned"
+        ), "Unexpected number of dates returned"
         assert (
             multi_gtfs_fixture.get_dates()[0] == "20230605"
         ), "min not as expected"
@@ -505,7 +505,9 @@ class TestMultiGtfsInstance(object):
         assert (
             multi_gtfs_altered_fixture.get_dates()[0] == "20220517"
         ), "min not as expected"
-        assert multi_gtfs_altered_fixture.get_dates()[1] == "20240613"
+        assert (
+            multi_gtfs_altered_fixture.get_dates()[1] == "20240613"
+        ), "max not as expected"
         # return_range=False
         assert (
             len(multi_gtfs_altered_fixture.get_dates(return_range=False)) == 6


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
This PR add an additional method to `MultiGtfsInstance`. This is the `.get_dates `method. This allows for the range of dates between all GTFS files to be returned.

Fixes #215 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Windows 10
* Python version: 3.9.13
* Java version: N/A
* Python management system: Conda

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
