### PR TITLE
235 create synthetic calendar if only calendar dates is used

### DIFF
--- a/src/transport_performance/gtfs/calendar.py
+++ b/src/transport_performance/gtfs/calendar.py
@@ -1,7 +1,7 @@
 """Cleaners & utilities specific to the calendar table."""
 import calendar
+from copy import deepcopy
 
-import numpy as np
 import pandas as pd
 
 from transport_performance.utils.defence import (
@@ -42,43 +42,38 @@ def create_calendar_from_dates(calendar_dates: pd.DataFrame) -> pd.DataFrame:
     exp_cols = ["service_id", "date", "exception_type"]
     for nm in exp_cols:
         _check_column_in_df(calendar_dates, nm)
-
-    # create an empty calendar df
     days = [day.lower() for day in calendar.day_name]
-    new_calendar = pd.DataFrame()
-    new_calendar["service_id"] = calendar_dates["service_id"].unique()
-    day_df = pd.DataFrame(
-        {i: np.zeros(len(new_calendar), dtype="int8") for i in days},
-        index=list(range(0, len(new_calendar))),
-    )
-    new_calendar = pd.concat([new_calendar, day_df], axis=1)
-    # create the start and end_date columns
-    new_calendar["start_date"] = ""
-    new_calendar["end_date"] = ""
-    new_calendar.set_index(new_calendar["service_id"], inplace=True)
-    # update this empty calendar with values from calendar_dates
-    for i, r in calendar_dates.iterrows():
-        # only update if calendar_dates exception_type is 1 (adding a service)
-        # Type 2 removes a service and will override the calendar
-        if r["exception_type"] == 1:
-            date_affected = r["date"]
-            day_affected = pd.to_datetime(date_affected).weekday()
-            # update weekday column entry to show the service runs on that day
-            new_calendar.loc[
-                r["service_id"], new_calendar.columns[day_affected + 1]
-            ] = 1
-            # update the start & end date columns
-            s_date = new_calendar.loc[r["service_id"], "start_date"]
-            if s_date == "":
-                new_calendar.loc[r["service_id"], "start_date"] = date_affected
-            else:
-                s_date = min(s_date, date_affected)
-                new_calendar.loc[r["service_id"], "start_date"] = s_date
-            e_date = new_calendar.loc[r["service_id"], "end_date"]
-            if e_date == "":
-                new_calendar.loc[r["service_id"], "end_date"] = date_affected
-            else:
-                e_date = max(e_date, date_affected)
-                new_calendar.loc[r["service_id"], "end_date"] = e_date
+    # clean calendar_dates
+    cal1 = calendar_dates[calendar_dates.exception_type == 1].copy()
+    cal1.drop("exception_type", axis=1, inplace=True)
+    # get list of dates and convert to days of the week
+    grouped = cal1.groupby("service_id").agg({"date": lambda x: list(set(x))})
 
-    return new_calendar.reset_index(drop=True)
+    def _get_day_name(date: str) -> str:
+        """Small helper function to get the named day of the week."""
+        day_index = pd.to_datetime(date).weekday()
+        return days[day_index]
+
+    grouped["days"] = grouped["date"].apply(
+        lambda x: list(set([_get_day_name(d) for d in x]))
+    )
+    # start and end date
+    grouped["start_date"] = grouped["date"].apply(lambda x: min(x))
+    grouped["end_date"] = grouped["date"].apply(lambda x: max(x))
+    # clean up unused data
+    grouped.drop("date", axis=1, inplace=True)
+    grouped.reset_index(inplace=True)
+    # add a column for each day
+    for day in days:
+        grouped[day] = (
+            grouped["days"]
+            .apply(lambda x: 1 if day in x else 0)
+            .astype("int8")
+        )
+    grouped.drop("days", axis=1)
+    # re-order index
+    order = deepcopy(days)
+    order.insert(0, "service_id")
+    order.append("start_date")
+    order.append("end_date")
+    return grouped.loc[:, order]

--- a/src/transport_performance/gtfs/calendar.py
+++ b/src/transport_performance/gtfs/calendar.py
@@ -48,7 +48,7 @@ def create_calendar_from_dates(calendar_dates: pd.DataFrame) -> pd.DataFrame:
     new_calendar = pd.DataFrame()
     new_calendar["service_id"] = calendar_dates["service_id"].unique()
     day_df = pd.DataFrame(
-        {i: np.zeros(len(new_calendar), dtype=int) for i in days},
+        {i: np.zeros(len(new_calendar), dtype="int8") for i in days},
         index=list(range(0, len(new_calendar))),
     )
     new_calendar = pd.concat([new_calendar, day_df], axis=1)
@@ -59,6 +59,7 @@ def create_calendar_from_dates(calendar_dates: pd.DataFrame) -> pd.DataFrame:
     # update this empty calendar with values from calendar_dates
     for i, r in calendar_dates.iterrows():
         # only update if calendar_dates exception_type is 1 (adding a service)
+        # Type 2 removes a service and will override the calendar
         if r["exception_type"] == 1:
             date_affected = r["date"]
             day_affected = pd.to_datetime(date_affected).weekday()
@@ -79,8 +80,5 @@ def create_calendar_from_dates(calendar_dates: pd.DataFrame) -> pd.DataFrame:
             else:
                 e_date = max(e_date, date_affected)
                 new_calendar.loc[r["service_id"], "end_date"] = e_date
-        else:
-            # Type 2 removes a service and will override the calendar
-            pass
 
     return new_calendar.reset_index(drop=True)

--- a/src/transport_performance/gtfs/calendar.py
+++ b/src/transport_performance/gtfs/calendar.py
@@ -15,8 +15,8 @@ def create_calendar_from_dates(calendar_dates: pd.DataFrame) -> pd.DataFrame:
 
     Use this in cases where a gtfs feed has elected to use a calendar-dates
     table and no calendar. Only adds values for calendar_dates entries tagged
-    as exception_type 1. Exception_type 2 is not treated. Those entries will
-    are left to override calendar values.
+    as exception_type 1. Exception_type 2 is not treated. Those entries are
+    ignored whilst making the calendar table.
 
     Parameters
     ----------

--- a/src/transport_performance/gtfs/calendar.py
+++ b/src/transport_performance/gtfs/calendar.py
@@ -1,0 +1,86 @@
+"""Cleaners & utilities specific to the calendar table."""
+import calendar
+
+import numpy as np
+import pandas as pd
+
+from transport_performance.utils.defence import (
+    _type_defence,
+    _check_column_in_df,
+)
+
+
+def create_calendar_from_dates(calendar_dates: pd.DataFrame) -> pd.DataFrame:
+    """Use the calendar_dates table to populate a calendar table.
+
+    Use this in cases where a gtfs feed has elected to use a calendar-dates
+    table and no calendar. Only adds values for calendar_dates entries tagged
+    as exception_type 1. Exception_type 2 is not treated. Those entries will
+    are left to override calendar values.
+
+    Parameters
+    ----------
+    calendar_dates : pd.DataFrame
+        The calendar_dates table.
+
+    Returns
+    -------
+    pd.DataFrame
+        A calendar table based on values in the calendar_dates table.
+
+    Raises
+    ------
+    TypeError
+        `calendar_dates` is not a pd.DataFrame
+    IndexError
+        `calendar_dates` does not contain any of the following columns -
+        service_id, date, exception_type.
+
+    """
+    # defence checking
+    _type_defence(calendar_dates, "calendar_dates", pd.DataFrame)
+    exp_cols = ["service_id", "date", "exception_type"]
+    for nm in exp_cols:
+        _check_column_in_df(calendar_dates, nm)
+
+    # create an empty calendar df
+    days = [day.lower() for day in calendar.day_name]
+    new_calendar = pd.DataFrame()
+    new_calendar["service_id"] = calendar_dates["service_id"].unique()
+    day_df = pd.DataFrame(
+        {i: np.zeros(len(new_calendar), dtype=int) for i in days},
+        index=list(range(0, len(new_calendar))),
+    )
+    new_calendar = pd.concat([new_calendar, day_df], axis=1)
+    # create the start and end_date columns
+    new_calendar["start_date"] = ""
+    new_calendar["end_date"] = ""
+    new_calendar.set_index(new_calendar["service_id"], inplace=True)
+    # update this empty calendar with values from calendar_dates
+    for i, r in calendar_dates.iterrows():
+        # only update if calendar_dates exception_type is 1 (adding a service)
+        if r["exception_type"] == 1:
+            date_affected = r["date"]
+            day_affected = pd.to_datetime(date_affected).weekday()
+            # update weekday column entry to show the service runs on that day
+            new_calendar.loc[
+                r["service_id"], new_calendar.columns[day_affected + 1]
+            ] = 1
+            # update the start & end date columns
+            s_date = new_calendar.loc[r["service_id"], "start_date"]
+            if s_date == "":
+                new_calendar.loc[r["service_id"], "start_date"] = date_affected
+            else:
+                s_date = min(s_date, date_affected)
+                new_calendar.loc[r["service_id"], "start_date"] = s_date
+            e_date = new_calendar.loc[r["service_id"], "end_date"]
+            if e_date == "":
+                new_calendar.loc[r["service_id"], "end_date"] = date_affected
+            else:
+                e_date = max(e_date, date_affected)
+                new_calendar.loc[r["service_id"], "end_date"] = e_date
+        else:
+            # Type 2 removes a service and will override the calendar
+            pass
+
+    return new_calendar.reset_index(drop=True)

--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -19,6 +19,7 @@ from transport_performance.utils.defence import (
     _check_parent_dir_exists,
     _enforce_file_extension,
 )
+from transport_performance.gtfs.calendar import create_calendar_from_dates
 
 
 class MultiGtfsInstance:
@@ -111,6 +112,25 @@ class MultiGtfsInstance:
         self.paths = path
         # instantiate the GtfsInstance's
         self.instances = [GtfsInstance(fpath) for fpath in path]
+        # ensure calendar is populated
+        for i, inst in enumerate(self.instances):
+            if inst.feed.calendar is None:
+                if inst.feed.calendar_dates is None:
+                    raise FileNotFoundError(
+                        "Both calendar and calendar_dates is empty for feed "
+                        + self.paths[i]
+                    )
+                else:
+                    warnings.warn(
+                        f"No calendar found for {self.paths[i]}. Creating from"
+                        " calendar dates"
+                    )
+                    # store calendar_dates
+                    self.instances[
+                        i
+                    ].feed.calendar = create_calendar_from_dates(
+                        calendar_dates=inst.feed.calendar_dates
+                    )
 
     def save_feeds(self, dir: Union[pathlib.Path, str]) -> None:
         """Save the GtfsInstances to a directory.

--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -117,7 +117,7 @@ class MultiGtfsInstance:
             if inst.feed.calendar is None:
                 if inst.feed.calendar_dates is None:
                     raise FileNotFoundError(
-                        "Both calendar and calendar_dates is empty for feed "
+                        "Both calendar and calendar_dates are empty for feed "
                         + self.paths[i]
                     )
                 else:

--- a/tests/gtfs/test_calendar.py
+++ b/tests/gtfs/test_calendar.py
@@ -21,11 +21,11 @@ class TestCreateCalendarFromDates(object):
             )
 
     def test_create_calendar_passes_no_exception_type_2(self):
-        """Check output calendar is as epected without exception_type 2."""
+        """Check output calendar is as expected without exception_type 2."""
         mock_dates = pd.DataFrame(
             {
                 "service_id": ["00A", "00A", "00A"],
-                "date": ["19840426", "19840426", "20240426"],
+                "date": ["19840426", "19840427", "20240426"],
                 "exception_type": [1, 1, 1],
             }
         )
@@ -52,5 +52,40 @@ class TestCreateCalendarFromDates(object):
                     "end_date": ["20240426"],
                 },
                 index=[0],
+            ),
+        )
+
+    def test_create_calendar_passes_with_exception_type_2(self):
+        """Check output calendar is as expected with exception_type 2."""
+        mock_dates = pd.DataFrame(
+            {
+                "service_id": ["00A", "00B", "00B"],
+                "date": ["19840426", "19840426", "20240426"],
+                "exception_type": [1, 1, 2],
+            }
+        )
+        out_calendar = create_calendar_from_dates(mock_dates)
+        assert isinstance(
+            out_calendar, pd.DataFrame
+        ), f"Expected dataframe, found {type(out_calendar)}"
+        n_rows = len(out_calendar)
+        assert n_rows == 2, f"Expected df length 2, found {n_rows}"
+        # check values are as expected. Dates are Thu & Fri respectively.
+        pd.testing.assert_frame_equal(
+            out_calendar,
+            pd.DataFrame(
+                {
+                    "service_id": ["00A", "00B"],
+                    "monday": [0, 0],
+                    "tuesday": [0, 0],
+                    "wednesday": [0, 0],
+                    "thursday": [1, 1],
+                    "friday": [0, 0],
+                    "saturday": [0, 0],
+                    "sunday": [0, 0],
+                    "start_date": ["19840426", "19840426"],
+                    "end_date": ["19840426", "19840426"],
+                },
+                index=[0, 1],
             ),
         )

--- a/tests/gtfs/test_calendar.py
+++ b/tests/gtfs/test_calendar.py
@@ -1,4 +1,5 @@
 """Test calendar utilities."""
+import calendar
 import pytest
 
 import pandas as pd
@@ -36,23 +37,28 @@ class TestCreateCalendarFromDates(object):
         n_rows = len(out_calendar)
         assert n_rows == 1, f"Expected df length 1, found {n_rows}"
         # check values are as expected. Dates are Thu & Fri respectively.
+        exp_calendar = pd.DataFrame(
+            {
+                "service_id": ["00A"],
+                "monday": [0],
+                "tuesday": [0],
+                "wednesday": [0],
+                "thursday": [1],
+                "friday": [1],
+                "saturday": [0],
+                "sunday": [0],
+                "start_date": ["19840426"],
+                "end_date": ["20240426"],
+            },
+            index=[0],
+        )
+        weekdays = [day.lower() for day in calendar.day_name]
+        for nm in exp_calendar.columns:
+            if nm in weekdays:
+                exp_calendar[nm] = exp_calendar[nm].astype("int8")
         pd.testing.assert_frame_equal(
             out_calendar,
-            pd.DataFrame(
-                {
-                    "service_id": ["00A"],
-                    "monday": [0],
-                    "tuesday": [0],
-                    "wednesday": [0],
-                    "thursday": [1],
-                    "friday": [1],
-                    "saturday": [0],
-                    "sunday": [0],
-                    "start_date": ["19840426"],
-                    "end_date": ["20240426"],
-                },
-                index=[0],
-            ),
+            exp_calendar,
         )
 
     def test_create_calendar_passes_with_exception_type_2(self):
@@ -65,6 +71,25 @@ class TestCreateCalendarFromDates(object):
             }
         )
         out_calendar = create_calendar_from_dates(mock_dates)
+        exp_calendar = pd.DataFrame(
+            {
+                "service_id": ["00A", "00B"],
+                "monday": [0, 0],
+                "tuesday": [0, 0],
+                "wednesday": [0, 0],
+                "thursday": [1, 1],
+                "friday": [0, 0],
+                "saturday": [0, 0],
+                "sunday": [0, 0],
+                "start_date": ["19840426", "19840426"],
+                "end_date": ["19840426", "19840426"],
+            },
+            index=[0, 1],
+        )
+        weekdays = [day.lower() for day in calendar.day_name]
+        for nm in exp_calendar.columns:
+            if nm in weekdays:
+                exp_calendar[nm] = exp_calendar[nm].astype("int8")
         assert isinstance(
             out_calendar, pd.DataFrame
         ), f"Expected dataframe, found {type(out_calendar)}"
@@ -80,19 +105,5 @@ class TestCreateCalendarFromDates(object):
         # check values are as expected. Dates are Thu & Fri respectively.
         pd.testing.assert_frame_equal(
             out_calendar,
-            pd.DataFrame(
-                {
-                    "service_id": ["00A", "00B"],
-                    "monday": [0, 0],
-                    "tuesday": [0, 0],
-                    "wednesday": [0, 0],
-                    "thursday": [1, 1],
-                    "friday": [0, 0],
-                    "saturday": [0, 0],
-                    "sunday": [0, 0],
-                    "start_date": ["19840426", "19840426"],
-                    "end_date": ["19840426", "19840426"],
-                },
-                index=[0, 1],
-            ),
+            exp_calendar,
         )

--- a/tests/gtfs/test_calendar.py
+++ b/tests/gtfs/test_calendar.py
@@ -60,8 +60,8 @@ class TestCreateCalendarFromDates(object):
         mock_dates = pd.DataFrame(
             {
                 "service_id": ["00A", "00B", "00B"],
-                "date": ["19840426", "19840426", "20240426"],
-                "exception_type": [1, 1, 2],
+                "date": ["19840426", "20240426", "19840426"],
+                "exception_type": [1, 2, 1],
             }
         )
         out_calendar = create_calendar_from_dates(mock_dates)
@@ -70,6 +70,13 @@ class TestCreateCalendarFromDates(object):
         ), f"Expected dataframe, found {type(out_calendar)}"
         n_rows = len(out_calendar)
         assert n_rows == 2, f"Expected df length 2, found {n_rows}"
+        # check the exception type 2 value didn't impact the table
+        assert (
+            out_calendar.iloc[1, -1] != "20240426"
+        ), "Did not expect date 20240426 to appear in out calendar."
+        assert (
+            out_calendar.loc[1, "friday"] == 0
+        ), "Did not expect calendar to show service 00B to runs on Friday."
         # check values are as expected. Dates are Thu & Fri respectively.
         pd.testing.assert_frame_equal(
             out_calendar,

--- a/tests/gtfs/test_calendar.py
+++ b/tests/gtfs/test_calendar.py
@@ -1,0 +1,21 @@
+"""Test calendar utilities."""
+import pytest
+
+import pandas as pd
+
+from transport_performance.gtfs.calendar import create_calendar_from_dates
+
+
+class TestCreateCalendarFromDates(object):
+    """Tests for create_calendar_from_dates."""
+
+    def test_create_calendar_from_dates_defence(self):
+        """Test defensive checks for create_calendar_from_dates."""
+        with pytest.raises(TypeError, match=".DataFrame'>. Got <class 'int'>"):
+            create_calendar_from_dates(calendar_dates=1)
+        with pytest.raises(
+            IndexError, match="service_id' is not a column in the dataframe."
+        ):
+            create_calendar_from_dates(
+                calendar_dates=pd.DataFrame({"foo": 0}, index=[0])
+            )

--- a/tests/gtfs/test_calendar.py
+++ b/tests/gtfs/test_calendar.py
@@ -19,3 +19,38 @@ class TestCreateCalendarFromDates(object):
             create_calendar_from_dates(
                 calendar_dates=pd.DataFrame({"foo": 0}, index=[0])
             )
+
+    def test_create_calendar_passes_no_exception_type_2(self):
+        """Check output calendar is as epected without exception_type 2."""
+        mock_dates = pd.DataFrame(
+            {
+                "service_id": ["00A", "00A", "00A"],
+                "date": ["19840426", "19840426", "20240426"],
+                "exception_type": [1, 1, 1],
+            }
+        )
+        out_calendar = create_calendar_from_dates(mock_dates)
+        assert isinstance(
+            out_calendar, pd.DataFrame
+        ), f"Expected dataframe, found {type(out_calendar)}"
+        n_rows = len(out_calendar)
+        assert n_rows == 1, f"Expected df length 1, found {n_rows}"
+        # check values are as expected. Dates are Thu & Fri respectively.
+        pd.testing.assert_frame_equal(
+            out_calendar,
+            pd.DataFrame(
+                {
+                    "service_id": ["00A"],
+                    "monday": [0],
+                    "tuesday": [0],
+                    "wednesday": [0],
+                    "thursday": [1],
+                    "friday": [1],
+                    "saturday": [0],
+                    "sunday": [0],
+                    "start_date": ["19840426"],
+                    "end_date": ["20240426"],
+                },
+                index=[0],
+            ),
+        )

--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -120,13 +120,14 @@ class TestMultiGtfsInstance(object):
                         os.path.join(tmp_chester, filename), arcname=filename
                     )
         zip_ref.close()
+        gtfs = MultiGtfsInstance(broken_feed)
         # a feed exists that does not contain any calendar info. mgtfs should
-        # raise.
+        # raise when checking calendars
         with pytest.raises(
             FileNotFoundError,
             match="Both calendar and calendar_dates are empty for feed",
         ):
-            MultiGtfsInstance(broken_feed)
+            gtfs.ensure_populated_calendars()
 
     def test_init_missing_calendar(self, multi_gtfs_paths, tmp_path):
         """Test init when calendar is missing.
@@ -176,6 +177,7 @@ class TestMultiGtfsInstance(object):
         subprocess.run(["rm", "-r", tmp_chester])
         # we can now go ahead with multigtfs instantiation from the tmp
         m_gtfs = MultiGtfsInstance(tmp_path)
+        m_gtfs.ensure_populated_calendars()
         which_chester = ["chester" in i for i in m_gtfs.paths]
         which_chester = [i for i, x in enumerate(which_chester) if x][0]
         updated_calendar = m_gtfs.instances[which_chester].feed.calendar


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Note - 'synthetic' was a poor choice of words. This PR aims to create a full calendar from a calendar_dates table, if calendar was not available. 

MultiGtfsInstance will now also check for the presence of calendar and calendar_dates on init , creating the calendar table if missing and raising FileNotFoundError if both tables are absent.

Fixes #235 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
Although calendar is conditionally required, our GTFS pipelines were failing if they were absent and the feed specified everything in a calendar_dates table instead. The new approach uses calendar_dates to create a calendar is it is absent.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: macos
* Python version: 3.9.13
* Java version: openjdk 11.0.19 2023-04-18 LTS
* Python management system: pip

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings # warns if calendar is missing and creates one from calendar_dates
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
