### PR TITLE
224 gtfs kit save overwrite

### DIFF
--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -112,19 +112,38 @@ class MultiGtfsInstance:
         # instantiate the GtfsInstance's
         self.instances = [GtfsInstance(fpath) for fpath in path]
 
-    def save_feeds(self, dir: Union[pathlib.Path, str]) -> None:
+    def save_feeds(
+        self,
+        dir: Union[pathlib.Path, str],
+        suffix: str = None,
+        file_names: list = None,
+        overwrite: bool = False,
+    ) -> None:
         """Save the GtfsInstances to a directory.
 
         Parameters
         ----------
         dir : Union[pathlib.Path, str]
             The directory to export the GTFS files into.
+        suffix : str
+            The suffix to apply to save names. The 'file_name' param takes
+            priority here.
+        file_names : list
+            A list of save names for the altered GTFS. The list must be the
+            same length as the number of GTFS instances. Takes priority over
+            the 'suffix' param.
+        overwrite : bool
+            Whether or not to overwrite the pre-existing saves with matching
+            paths.
 
         Returns
         -------
         None
 
         """
+        _type_defence(suffix, "suffix", (str, type(None)))
+        _type_defence(file_names, "file_names", (list, type(None)))
+        _type_defence(overwrite, "overwrite", bool)
         defence_path = os.path.join(dir, "test.test")
         _check_parent_dir_exists(defence_path, "dir", create=True)
         save_paths = [

--- a/src/transport_performance/gtfs/multi_validation.py
+++ b/src/transport_performance/gtfs/multi_validation.py
@@ -115,7 +115,7 @@ class MultiGtfsInstance:
     def save_feeds(
         self,
         dir: Union[pathlib.Path, str],
-        suffix: str = None,
+        suffix: str = "_new",
         file_names: list = None,
         overwrite: bool = False,
     ) -> None:
@@ -131,7 +131,8 @@ class MultiGtfsInstance:
         file_names : list
             A list of save names for the altered GTFS. The list must be the
             same length as the number of GTFS instances. Takes priority over
-            the 'suffix' param.
+            the 'suffix' param. Names will be used in order of the instances
+            (access using self.instances()).
         overwrite : bool
             Whether or not to overwrite the pre-existing saves with matching
             paths.
@@ -146,16 +147,22 @@ class MultiGtfsInstance:
         _type_defence(overwrite, "overwrite", bool)
         defence_path = os.path.join(dir, "test.test")
         _check_parent_dir_exists(defence_path, "dir", create=True)
-        save_paths = [
-            os.path.join(
-                dir, os.path.splitext(os.path.basename(p))[0] + "_new.zip"
-            )
-            for p in self.paths
-        ]
+        # format save locations
+        if not file_names:
+            save_paths = [
+                os.path.join(
+                    dir,
+                    os.path.splitext(os.path.basename(p))[0] + f"{suffix}.zip",
+                )
+                for p in self.paths
+            ]
+        else:
+            save_paths = [os.path.join(dir, p) for p in file_names]
+        # save gtfs
         progress = tqdm(zip(save_paths, self.instances), total=len(self.paths))
         for path, inst in progress:
             progress.set_description(f"Saving at {path}")
-            inst.save(path)
+            inst.save(path, overwrite=overwrite)
         return None
 
     def clean_feeds(self, clean_kwargs: Union[dict, None] = None) -> None:

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -1666,6 +1666,7 @@ class GtfsInstance:
         None
 
         """
+        _type_defence(overwrite, "overwrite", bool)
         _check_parent_dir_exists(path, "path", True)
         path = _enforce_file_extension(
             path, exp_ext=".zip", default_ext=".zip", param_nm="path"

--- a/src/transport_performance/gtfs/validation.py
+++ b/src/transport_performance/gtfs/validation.py
@@ -1648,13 +1648,18 @@ class GtfsInstance:
 
         return None
 
-    def save(self, path: Union[str, pathlib.Path]) -> None:
+    def save(
+        self, path: Union[str, pathlib.Path], overwrite: bool = False
+    ) -> None:
         """Save the cleaned gtfs file.
 
         Parameters
         ----------
         path : Union[str, pathlib.Path]
             The path to save the GTFS file to. E.g., outputs/cleaned_gtfs.zip
+        overwrite : bool
+            Whether or not to overwrite any pre-existing files at the given
+            path
 
         Returns
         -------
@@ -1665,6 +1670,14 @@ class GtfsInstance:
         path = _enforce_file_extension(
             path, exp_ext=".zip", default_ext=".zip", param_nm="path"
         )
+        if os.path.exists(path):
+            if overwrite:
+                os.remove(path)
+            else:
+                raise FileExistsError(
+                    f"File already exists at path {path}. If you wish to "
+                    "overwrite this file, please pass overwrite=True"
+                )
         self.feed.write(path)
         return None
 

--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -98,6 +98,19 @@ class TestMultiGtfsInstance(object):
         assert np.array_equal(
             np.sort(expected_paths), np.sort(found_paths)
         ), "GtfsInstances not saved as expected"
+        # test saves with filenames
+        file_name_dir = os.path.join(tmp_path, "filenames")
+        gtfs.save_feeds(
+            dir=file_name_dir, file_names=["test1.zip", "test2.zip"]
+        )
+        assert len(os.listdir(file_name_dir)) == 2, "Not enough files saved"
+        found_paths = [
+            os.path.basename(fpath)
+            for fpath in glob.glob(file_name_dir + "/*.zip")
+        ]
+        assert np.array_equal(
+            found_paths, ["test1.zip", "test2.zip"]
+        ), "File names not saved correctly"
 
     def test_clean_feeds_defences(self, multi_gtfs_fixture):
         """Defensive tests for .clean_feeds()."""

--- a/tests/gtfs/test_multi_validation.py
+++ b/tests/gtfs/test_multi_validation.py
@@ -109,7 +109,7 @@ class TestMultiGtfsInstance(object):
             for fpath in glob.glob(file_name_dir + "/*.zip")
         ]
         assert np.array_equal(
-            found_paths, ["test1.zip", "test2.zip"]
+            np.sort(found_paths), np.sort(["test1.zip", "test2.zip"])
         ), "File names not saved correctly"
 
     def test_clean_feeds_defences(self, multi_gtfs_fixture):

--- a/tests/gtfs/test_validation.py
+++ b/tests/gtfs/test_validation.py
@@ -1075,8 +1075,24 @@ class TestGtfsInstance(object):
                 gtfs_fixture.save(complete_path)
         else:
             with does_not_raise():
-                gtfs_fixture.save(complete_path)
+                gtfs_fixture.save(complete_path, overwrite=True)
         assert os.path.exists(expected_path), "GTFS not saved correctly"
+
+    def test_save_overwrite(self, tmp_path, gtfs_fixture):
+        """Test the .save()'s method of GtfsInstance overwrite feature."""
+        # original save
+        save_pth = f"{tmp_path}/test_save.zip"
+        gtfs_fixture.save(save_pth, overwrite=True)
+        assert os.path.exists(save_pth), "GTFS not saved at correct path"
+        # test saving without overwrite enabled
+        with pytest.raises(
+            FileExistsError, match="File already exists at path.*"
+        ):
+            gtfs_fixture.save(f"{tmp_path}/test_save.zip", overwrite=False)
+        # test saving with overwrite enabled raises no errors
+        with does_not_raise():
+            gtfs_fixture.save(f"{tmp_path}/test_save.zip", overwrite=True)
+        assert os.path.exists(save_pth), "GTFS save not found"
 
     @pytest.mark.parametrize(
         "date, expected_len",


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. ---!>
This PR gives better functionality to the MultiGtfsInstance.save_feeds() method.
It also fixes an issue where gtfs-kit would not overwrite previous saves

Fixes #224 
Fixes #240 

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->

Test configuration details:
* OS: Windows 10
* Python version: 2.9.13
* Java version: N/A
* Python management system: Conda

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional comments
<!--- Add any additional comments here --->
