### PR TITLE
chore: Pin pytest version lower than 8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ rioxarray
 geopandas
 geocube
 pyproj>=3.6.0
-pytest
+pytest<8.0.0 # avoid breaking change 'CallSpec2' object has no attribute 'funcargs'
 coverage
 pyprojroot
 pytest-lazy-fixture


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Patch to avoid fail due to CallSpec2 AttributeError originating from pytest-8.0.0

Fixes #244
## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->

## Type of change
<!--- Please select from the options below --->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Advice for reviewer

Error [originating from current api breaking change](https://github.com/pytest-dev/pytest/blob/21bec6cfbed7ae36478aeff956919727c2bb8641/src/_pytest/python.py#L1046-L1066).  I presume it to be linked to our parametrized testing. Not much current chatter about this change right now from my casual googling.

Implementation in pytest 7.4.4:

```
@final
@dataclasses.dataclass(frozen=True)
class CallSpec2:
    """A planned parameterized invocation of a test function.

    Calculated during collection for a given test function's Metafunc.
    Once collection is over, each callspec is turned into a single Item
    and stored in item.callspec.
    """

    # arg name -> arg value which will be passed to the parametrized test
    # function (direct parameterization).
    funcargs: Dict[str, object] = dataclasses.field(default_factory=dict)
    # arg name -> arg value which will be passed to a fixture of the same name
    # (indirect parametrization).
    params: Dict[str, object] = dataclasses.field(default_factory=dict)
    # arg name -> arg index.
    indices: Dict[str, int] = dataclasses.field(default_factory=dict)
    # Used for sorting parametrized resources.
    _arg2scope: Dict[str, Scope] = dataclasses.field(default_factory=dict)
    # Parts which will be added to the item's name in `[..]` separated by "-".
    _idlist: List[str] = dataclasses.field(default_factory=list)
    # Marks which will be applied to the item.
    marks: List[Mark] = dataclasses.field(default_factory=list)
```
